### PR TITLE
Removed comment from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,3 @@
-/* 
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
-
 {
 	"name": "bamboohr/api",
 	"require": {


### PR DESCRIPTION
When adding this to my composer.json it wouldn't load the Bamboo API because of the comment in it's JSON file.
