### PR TITLE
Don't assume we got an error message

### DIFF
--- a/BambooHR/API/API.php
+++ b/BambooHR/API/API.php
@@ -105,7 +105,9 @@ class BambooHTTPResponse {
 	 */
 	public function getErrorMessage() {
 		if($this->isError())
-			return $this->headers['X-BambooHR-Error-Messsage'];
+			return isset($this->headers['X-BambooHR-Error-Messsage'])
+				? $this->headers['X-BambooHR-Error-Messsage']
+				: $this->getContent();
 		return null;
 	}
 }


### PR DESCRIPTION
Calling the Bamboo API without an Internet connection results in objects like this:

```
O:31:"BambooHR\API\BambooHTTPResponse":3:{s:10:"statusCode";i:0;s:7:"headers";a:0:{}s:7:"content";s:16:"Connection error";}
```

Calling getErrorMessage on this (in our case, to log the error) causes "Undefined index: X-BambooHR-Error-Messsage", since that header isn't set. This change prevents that error and returns a useful message instead.
