### PR TITLE
Url encoding on fields list 

### DIFF
--- a/BambooHR/API/API.php
+++ b/BambooHR/API/API.php
@@ -335,7 +335,7 @@ class BambooAPI {
 	function getEmployee($employeeId, $fields=array()) {
 		$request=new BambooHTTPRequest();
 		$request->method="GET";
-		$request->url=$this->baseUrl."/v1/employees/".intval($employeeId)."/?fields=".implode(",",$fields);
+		$request->url=$this->baseUrl."/v1/employees/".intval($employeeId)."/?fields=".urlencode(implode(",",$fields));
 
 		return $this->httpHandler->sendRequest( $request );
 	}

--- a/BambooHR/API/API.php
+++ b/BambooHR/API/API.php
@@ -292,7 +292,7 @@ class BambooAPI {
 	 * @link http://www.bamboohr.com/api/documentation/login.php
 	 */
 	function requestSecretKey($applicationKey, $email, $password) {
-		$request=new HTTPRequest();
+		$request=new BambooHTTPRequest();
 		$request->method="POST";
 		$request->url=$this->baseUrl."/v1/login";
 		$request->content="applicationKey=".urlencode($applicationKey)."&user=".urlencode($email)."&password=".urlencode($password);


### PR DESCRIPTION
    If someone adds a field in bamboo with a hash char in it, it will break the
    fields= url, as it won't be encoded properly and will cause all fields
    after the one with a hash in to be ignored in the response.
    This adds encodeurl() around the fields= list so they should all be
    loaded properly.