### PR TITLE
Force Curl to work with HTTP/1 only

### DIFF
--- a/BambooHR/BambooCurlHTTP.php
+++ b/BambooHR/BambooCurlHTTP.php
@@ -52,6 +52,7 @@ class BambooCurlHTTP implements BambooHTTP {
 		$response = new BambooHTTPResponse();
 
 		$http = curl_init();
+		curl_setopt($http, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 		curl_setopt($http, CURLOPT_URL, $request->url );
 		curl_setopt($http, CURLOPT_CUSTOMREQUEST, $request->method );
 		curl_setopt($http, CURLOPT_HTTPHEADER, $request->headers );

--- a/BambooHR/BambooCurlHTTP.php
+++ b/BambooHR/BambooCurlHTTP.php
@@ -52,6 +52,7 @@ class BambooCurlHTTP implements BambooHTTP {
 		$response = new BambooHTTPResponse();
 
 		$http = curl_init();
+		
 		curl_setopt($http, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 		curl_setopt($http, CURLOPT_URL, $request->url );
 		curl_setopt($http, CURLOPT_CUSTOMREQUEST, $request->method );


### PR DESCRIPTION
In case of using newer curl version, which supports HTTP/2 (https://github.com/php/php-src/commit/1badfd8171119ef70a5d088068b9de88ba668f73), BambooAPI can't parse the headers, cause in HTTP/2 they come strlowered: https://httpwg.org/specs/rfc7540.html#HttpHeaders