### PR TITLE
Remove default IDE template contents

### DIFF
--- a/BambooHR/Injector/BambooHTTPRequestInjector.php
+++ b/BambooHR/Injector/BambooHTTPRequestInjector.php
@@ -1,10 +1,6 @@
 <?php
 /**
  * BambooHTTPRequest.php
- * @author    Daniel Mason <danielm@moo.com>
- * @copyright 2016 MOO
- * @license   proprietary
- * @see       https://www.moo.com
  */
 
 namespace BambooHR\API\Injector;

--- a/tests/BambooAPITest.php
+++ b/tests/BambooAPITest.php
@@ -1,10 +1,6 @@
 <?php
 /**
  * BambooAPITest.php
- * @author    Daniel Mason <danielm@moo.com>
- * @copyright 2016 MOO
- * @license   proprietary
- * @see       https://www.moo.com
  */
 
 namespace BambooHR\API\Tests;

--- a/tests/BambooCurlHTTPTest.php
+++ b/tests/BambooCurlHTTPTest.php
@@ -1,10 +1,6 @@
 <?php
 /**
  * BambooCurlHTTPTest.php
- * @author    Daniel Mason <danielm@moo.com>
- * @copyright 2016 MOO
- * @license   proprietary
- * @see       https://www.moo.com
  */
 
 namespace BambooHR\API\Tests;

--- a/tests/BambooHTTPRequestTest.php
+++ b/tests/BambooHTTPRequestTest.php
@@ -1,10 +1,6 @@
 <?php
 /**
  * BambooHTTPRequestTest.php
- * @author    Daniel Mason <danielm@moo.com>
- * @copyright 2016 MOO
- * @license   proprietary
- * @see       https://www.moo.com
  */
 
 namespace BambooHR\API\Tests;

--- a/tests/Injector/BambooHTTPRequestInjectorTest.php
+++ b/tests/Injector/BambooHTTPRequestInjectorTest.php
@@ -1,10 +1,6 @@
 <?php
 /**
  * BambooHTTPRequestInjectorTest.php
- * @author    Daniel Mason <danielm@moo.com>
- * @copyright 2016 MOO
- * @license   proprietary
- * @see       https://www.moo.com
  */
 
 namespace BambooHR\API\Tests\Injector;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,6 @@
 <?php
 /**
  * TestCase.php
- * @author    Daniel Mason <danielm@moo.com>
- * @copyright 2016 MOO
- * @license   proprietary
- * @see       https://www.moo.com
  */
 
 namespace BambooHR\API\Tests;


### PR DESCRIPTION
The assumption is that this was how PHPStorm or similar was configured
and it was accidentally committed like that years ago.

To be very explicit, MOO asserts no copyright over this code.