### PR TITLE
Adding codeowners with some basic defaults

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# All files default to the PlatAPI team
+* @BambooHR/platapi
+
+# Auto-generated SDK paths
+/lib/Api/ @BambooHR/platapi
+/lib/Model/ @BambooHR/platapi
+/docs/ @BambooHR/platapi
+/test/ @BambooHR/platapi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change that only affects GitHub review ownership/assignment and does not alter runtime code or behavior.
> 
> **Overview**
> Adds a `.github/CODEOWNERS` file that assigns **default ownership** of the repository (including generated SDK paths like `lib/Api`, `lib/Model`, `docs`, and `test`) to `@BambooHR/platapi`, ensuring reviews are automatically requested from the PlatAPI team.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f35d4a24e2ecde824e29b94a225094578b15286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->