### PR TITLE
[SPN-2932] Authenticate composer install via BambooHR GitHub App token

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,6 +13,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Generate a GitHub App token (for private composer deps)
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            phpcs
+
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -21,6 +31,8 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
+        env:
+          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ steps.generate-token.outputs.token }}"}}'
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Pull OpenAPI Generator Docker image


### PR DESCRIPTION
## Summary

Hotfix for [#75](https://github.com/BambooHR/bhr-api-php/pull/75) — the workflow failed during \`composer install\` because the \`bamboohr/phpcs\` dep lives in the private \`BambooHR/phpcs\` repo and the default \`GITHUB_TOKEN\` can't read it.

\`\`\`
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/BambooHR/phpcs.git/'
\`\`\`

## Fix

Mirror the pattern used in [\`BambooHR/error-management-service\`](https://github.com/BambooHR/error-management-service/blob/main/.github/workflows/phpunit.yml): mint a short-lived token via \`actions/create-github-app-token@v1\` scoped to the \`phpcs\` repo and pass it to composer through \`COMPOSER_AUTH\`.

Requires \`APP_ID\` (variable) and \`APP_PRIVATE_KEY\` (secret) to already be configured — these are set up org-wide.

## Test plan

- [ ] Re-run the SDK generation workflow and confirm \`composer install\` (and downstream steps) pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that affects dependency installation by introducing a GitHub App token; main risk is misconfiguration of `APP_ID`/`APP_PRIVATE_KEY` or token scoping causing workflow failures.
> 
> **Overview**
> Ensures the `Generate SDK` workflow can install private Composer dependencies by generating a short-lived GitHub App token (`actions/create-github-app-token@v1`) scoped to the `phpcs` repo and injecting it into `composer install` via `COMPOSER_AUTH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85ba33fb8e268ec5f455bc2046c6ee6de9bf2b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->