### PR TITLE
[SPN-2932] Use org-wide REPO_RO_APP_ID for composer auth

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,11 +14,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate a GitHub App token (for private composer deps)
+        # Uses the org-level read-only GitHub App (REPO_RO_APP_ID /
+        # REPO_RO_APP_PRIVATE_KEY) so no per-repo secret setup is needed.
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ vars.REPO_RO_APP_ID }}
+          private-key: ${{ secrets.REPO_RO_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
             phpcs


### PR DESCRIPTION
## Summary

Hotfix for [#76](https://github.com/BambooHR/bhr-api-php/pull/76) — that PR's \`vars.APP_ID\` reference evaluated to empty in \`bhr-api-php\` because the repo wasn't on the org-level allow-list for that variable, causing:

\`\`\`
Error: Input required and not supplied: app-id
\`\`\`

## Fix

Switch to \`vars.REPO_RO_APP_ID\` / \`secrets.REPO_RO_APP_PRIVATE_KEY\` — a separate org-wide read-only GitHub App that's available to **all** BambooHR repos by default. Per the [\`answers-data-deleter\` README](https://github.com/BambooHR/answers-data-deleter): "no per-repo secret setup needed."

This is the standard pattern for private composer deps across the org. Examples that already use it:
- [\`BambooHR/main/.github/workflows/generate-main-openapi-specs.yml\`](https://github.com/BambooHR/main/blob/main/.github/workflows/generate-main-openapi-specs.yml)
- [\`BambooHR/actions/.github/workflows/php-generate-openapi-spec.yaml\`](https://github.com/BambooHR/actions/blob/main/.github/workflows/php-generate-openapi-spec.yaml)
- \`BambooHR/answers-data-deleter\`, \`BambooHR/agent-actions\`, \`BambooHR/agent-history-service\`, etc.

## Test plan

- [ ] Re-run the SDK generation workflow and confirm \`composer install\` succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just swaps which GitHub App credentials are used to mint a token for Composer; main risk is misconfigured org secrets/vars causing CI failures.
> 
> **Overview**
> Updates the `generate.yml` GitHub Actions workflow to mint the Composer auth token using the org-wide read-only GitHub App (`vars.REPO_RO_APP_ID` / `secrets.REPO_RO_APP_PRIVATE_KEY`) instead of per-repo credentials, with a clarifying comment about removing per-repo secret setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5c913e3dc16f07e3cb47a6cd83e5c2cda8c864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->