### PR TITLE
[SPN-2932] Revert composer auth back to APP_ID/APP_PRIVATE_KEY

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,13 +14,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate a GitHub App token (for private composer deps)
-        # Uses the org-level read-only GitHub App (REPO_RO_APP_ID /
-        # REPO_RO_APP_PRIVATE_KEY) so no per-repo secret setup is needed.
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.REPO_RO_APP_ID }}
-          private-key: ${{ secrets.REPO_RO_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
             phpcs


### PR DESCRIPTION
## Summary

Revert [#77](https://github.com/BambooHR/bhr-api-php/pull/77). \`REPO_RO_APP_ID\` is org-scoped to private repos and \`bhr-api-php\` is public, so that pair doesn't resolve.

Aaron has put in an access request for \`APP_ID\` / \`APP_PRIVATE_KEY\` (the same pair used by [\`error-management-service/.github/workflows/phpunit.yml\`](https://github.com/BambooHR/error-management-service/blob/main/.github/workflows/phpunit.yml)). Once that lands, the workflow will run end-to-end.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI authentication inputs for fetching private Composer dependencies, which can break the workflow if secrets/vars are misconfigured.
> 
> **Overview**
> Reverts the `generate.yml` workflow’s GitHub App token generation to use `vars.APP_ID` and `secrets.APP_PRIVATE_KEY` instead of the repo read-only app credentials.
> 
> This affects how the workflow authenticates to fetch private Composer dependencies (e.g., `phpcs`) during the generate/lint/test job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5afb89373b06c6e761ba98b9b738e1ac3886f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->