### PR TITLE
[SPN-2932] Switch composer auth to documented REPO_RO_APP_ID

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,10 +14,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate a GitHub App token (for private composer deps)
-        # Per the BambooHR "Access other repos with your GitHub Action" doc
-        # (https://bamboohr.slite.com/app/docs/9BqBAxIM14DJ-O), REPO_RO_APP_ID
-        # and REPO_RO_APP_PRIVATE_KEY are the documented org-wide credentials
-        # for granting a workflow read access to other BambooHR repos.
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,11 +14,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Generate a GitHub App token (for private composer deps)
+        # Per the BambooHR "Access other repos with your GitHub Action" doc
+        # (https://bamboohr.slite.com/app/docs/9BqBAxIM14DJ-O), REPO_RO_APP_ID
+        # and REPO_RO_APP_PRIVATE_KEY are the documented org-wide credentials
+        # for granting a workflow read access to other BambooHR repos.
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ vars.REPO_RO_APP_ID }}
+          private-key: ${{ secrets.REPO_RO_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
             phpcs


### PR DESCRIPTION
## Summary

Per the BambooHR Slite doc [Access other repos with your GitHub Action](https://bamboohr.slite.com/app/docs/9BqBAxIM14DJ-O), the documented org-wide pattern for workflow read access to other BambooHR repos is:

\`\`\`yaml
app-id: \${{ vars.REPO_RO_APP_ID }}
private-key: \${{ secrets.REPO_RO_APP_PRIVATE_KEY }}
\`\`\`

[#78](https://github.com/BambooHR/bhr-api-php/pull/78) used \`APP_ID\` / \`APP_PRIVATE_KEY\`, which were copied from \`error-management-service\` — that pair appears to be a non-standard ad-hoc variable, not the documented standard.

## Caveat

Earlier in [#77](https://github.com/BambooHR/bhr-api-php/pull/77) we tried \`REPO_RO_APP_ID\` and it failed because every other repo successfully using it is **internal** while \`bhr-api-php\` is **public** — the org variable was almost certainly scoped to private repos only.

If this run still fails with \`Input required and not supplied: app-id\`, we'll ping a bridgefour admin (\`cubiclelord\` / \`ozmian\`) to extend \`REPO_RO_APP_ID\` / \`REPO_RO_APP_PRIVATE_KEY\` scope to include public repos (or add \`bhr-api-php\` to the allow-list).

Aligning with the documented standard now means future public-SDK repos (PHP SDK being public too) won't have to re-discover the right variable.

## Test plan

- [ ] Re-run the SDK generation workflow and confirm token generation succeeds
- [ ] If token step still fails, follow up with bridgefour for public-repo scope

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; the main risk is the generation job failing if the new org variables/secrets aren’t scoped to this public repo.
> 
> **Overview**
> Switches the `Generate SDK` GitHub Actions workflow to mint its GitHub App token using the documented `vars.REPO_RO_APP_ID` and `secrets.REPO_RO_APP_PRIVATE_KEY` instead of `APP_ID`/`APP_PRIVATE_KEY` for accessing private Composer dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b376000733bc033e79fcc9fd63295d582832f68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->