### PR TITLE
[SPN-2932] Switch composer auth to GHM-375 deploy key

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,15 +13,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Generate a GitHub App token (for private composer deps)
-        id: generate-token
-        uses: actions/create-github-app-token@v1
+      # Load the deploy key issued by GHM-375 so composer can fetch
+      # bamboohr/phpcs over SSH (composer.lock records the SSH URL
+      # git@github.com:BambooHR/phpcs.git, which the deploy key authorizes).
+      - name: Load private-repo deploy key
+        uses: webfactory/ssh-agent@v0.9.0
         with:
-          app-id: ${{ vars.REPO_RO_APP_ID }}
-          private-key: ${{ secrets.REPO_RO_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            phpcs
+          ssh-private-key: ${{ secrets.GHM_375_PRIVATE_REPO_DEPLOY_KEY }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -31,8 +29,6 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        env:
-          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ steps.generate-token.outputs.token }}"}}'
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Pull OpenAPI Generator Docker image

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -16,8 +16,16 @@ jobs:
       # Load the deploy key issued by GHM-375 so composer can fetch
       # bamboohr/phpcs over SSH (composer.lock records the SSH URL
       # git@github.com:BambooHR/phpcs.git, which the deploy key authorizes).
+      #
+      # ⚠️ SECURITY: this repository is PUBLIC. The deploy key grants read
+      # access to a private repo. Do NOT add steps that print contents of
+      # vendor/bamboohr/phpcs/** (or anything else from a private dep) to
+      # workflow logs or upload them as artifacts — those become world-
+      # readable. Stick to running tools against the installed files.
       - name: Load private-repo deploy key
-        uses: webfactory/ssh-agent@v0.9.0
+        # v0.10.0 runs on Node 24. v0.9.0 is Node 20 and will break on
+        # GitHub-hosted runners after the Node-20 removal window.
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.GHM_375_PRIVATE_REPO_DEPLOY_KEY }}
 


### PR DESCRIPTION
## Summary

The admins issued \`GHM_375_PRIVATE_REPO_DEPLOY_KEY\` — a deploy key registered on \`BambooHR/phpcs\` with the secret available on \`bhr-api-php\` and \`bhr-api-python\`. This sidesteps the public-repo / org-level-App-vars limitation we hit in [#77](https://github.com/BambooHR/bhr-api-php/pull/77) and [#80](https://github.com/BambooHR/bhr-api-php/pull/80).

## Change

\`\`\`diff
- - name: Generate a GitHub App token (for private composer deps)
-   uses: actions/create-github-app-token@v1
-   with:
-     app-id: \${{ vars.REPO_RO_APP_ID }}
-     private-key: \${{ secrets.REPO_RO_APP_PRIVATE_KEY }}
-     owner: \${{ github.repository_owner }}
-     repositories: |
-       phpcs
+ - name: Load private-repo deploy key
+   uses: webfactory/ssh-agent@v0.9.0
+   with:
+     ssh-private-key: \${{ secrets.GHM_375_PRIVATE_REPO_DEPLOY_KEY }}
\`\`\`

\`composer.lock\` already records the SSH URL (\`git@github.com:BambooHR/phpcs.git\`), so no \`composer.json\` change needed — composer authenticates via the ssh-agent automatically.

## Test plan

- [ ] Trigger the workflow manually and confirm \`composer install\` resolves \`bamboohr/phpcs\`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI authentication for pulling a private Composer dependency in a public repo; misconfiguration or accidental logging/artifact upload could expose private dependency contents or break installs.
> 
> **Overview**
> Updates the `Generate SDK` GitHub Actions workflow to install the private `bamboohr/phpcs` Composer dependency via an SSH deploy key (`GHM_375_PRIVATE_REPO_DEPLOY_KEY`) loaded with `webfactory/ssh-agent@v0.10.0`, replacing the prior GitHub App token + `COMPOSER_AUTH` approach.
> 
> Adds explicit security guidance in the workflow comments to avoid printing or artifacting private dependency contents from this public repository’s CI logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee30762fee2292a60d5791eb26491365880aae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->