### PR TITLE
[SPN-2933] sdk-update: fix composer auth + 64-KB PR body limit

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -37,7 +37,16 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
+        # --prefer-source (NOT --prefer-dist): forces composer to `git clone`
+        # each package from its source URL. composer.lock records
+        # `git@github.com:BambooHR/phpcs.git` for the private bamboohr/phpcs
+        # dep, which the GHM-375 deploy key authorizes over SSH. With
+        # --prefer-dist composer would instead try the GitHub Archive API
+        # (`https://api.github.com/repos/.../zipball/...`), which is HTTPS
+        # and returns 404 for private repos when the request isn't
+        # API-authenticated (GitHub hides existence of private repos from
+        # unauthenticated callers). The deploy key cannot help with that.
+        run: composer install --prefer-source --no-progress --no-interaction
 
       - name: Pull OpenAPI Generator Docker image
         run: docker pull openapitools/openapi-generator-cli:v7.16.0

--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -72,7 +72,16 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
+        # --prefer-source (NOT --prefer-dist): forces composer to `git clone`
+        # each package from its source URL. composer.lock records
+        # `git@github.com:BambooHR/phpcs.git` for the private bamboohr/phpcs
+        # dep, which the GHM-375 deploy key authorizes over SSH. With
+        # --prefer-dist composer would instead try the GitHub Archive API
+        # (`https://api.github.com/repos/.../zipball/...`), which is HTTPS
+        # and returns 404 for private repos when the request isn't
+        # API-authenticated (GitHub hides existence of private repos from
+        # unauthenticated callers). The deploy key cannot help with that.
+        run: composer install --prefer-source --no-progress --no-interaction
 
       # Python is needed for the orchestration scripts (fetch_spec.py,
       # build_pr_body.py, bump_version.py). All three are stdlib-only — no


### PR DESCRIPTION
## Summary

The first run of \`sdk-update.yml\` after merge of #82 [failed at "Install Composer dependencies"](https://github.com/BambooHR/bhr-api-php/actions/runs/26780073155/job/78941850313):

\`\`\`
Failed to download bamboohr/phpcs from dist: The
"https://api.github.com/repos/BambooHR/phpcs/zipball/<sha>" file could
not be downloaded (HTTP/2 404)
\`\`\`

## Root cause

\`composer install --prefer-dist\` resolves \`git@github.com:\` package source URLs to GitHub's **Archive API** (zipball endpoint), which is HTTPS. The GHM-375 deploy key authorizes SSH git operations, not HTTPS API calls.

GitHub returns **404** (not 401/403) for unauthenticated requests against private repos — a privacy-preserving default that hides existence of the repo. So the package looks "missing" rather than "unauthorized," which made the failure message confusing.

\`generate.yml\` has the identical install line and would hit the same failure on its next run. It's only been passing because we hadn't triggered it since switching from the App-token \`COMPOSER_AUTH\` approach to the deploy key. Fixing both keeps them in lockstep.

## Fix

\`\`\`diff
- run: composer install --prefer-dist --no-progress --no-interaction
+ run: composer install --prefer-source --no-progress --no-interaction
\`\`\`

\`--prefer-source\` makes composer \`git clone\` each package, which uses the \`composer.lock\`-recorded SSH URL (\`git@github.com:BambooHR/phpcs.git\`) and is authorized by the loaded deploy key. Public packagist deps (phpunit, phpstan, etc.) just clone from public GitHub URLs — no auth needed, modest perf cost.

## Tradeoff & escape hatch

\`--prefer-source\` is slower than \`--prefer-dist\` for the public packages (clone vs. zipball download). For an occasionally-run SDK pipeline that's fine. If perf becomes an issue we can use composer's \`config.preferred-install\` to opt in to source **only** for \`bamboohr/phpcs\` and keep dist for everything else.

Inline comment in both workflows documents the rationale so a future maintainer doesn't "optimize" back to \`--prefer-dist\` and break the build.

## Test plan

- [ ] Trigger \`sdk-update.yml\` after merge; "Install Composer dependencies" succeeds
- [ ] Trigger \`generate.yml\` and confirm it still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow flag and documentation changes; no runtime application or security logic changes.
> 
> **Overview**
> Fixes CI **Composer install** for the private **`bamboohr/phpcs`** dependency in **`generate.yml`** and **`sdk-update.yml`** by switching from **`--prefer-dist`** to **`--prefer-source`**, so installs use **SSH git clones** authorized by the GHM-375 deploy key instead of unauthenticated **GitHub zipball** URLs that 404 for private repos.
> 
> Inline comments in both workflows document why **`--prefer-dist`** must not be reintroduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb59ae6c3f4bc8352d00724071864712ff371569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->