### PR TITLE
[SPN-2933] Truncate oasdiff changelog to fit GitHub's 64-KB PR body limit

### DIFF
--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -323,6 +323,10 @@ jobs:
           GENERATION_STATUS: ${{ steps.status.outputs.result }}
           OLD_VERSION: ${{ steps.bump.outputs.old_version }}
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          # Passed through so the changelog-truncation suffix can deep-link
+          # back to this run when the oasdiff markdown is too big for the
+          # 64-KB PR body cap.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python scripts/build_pr_body.py \
             --classification .sdk-update/classification.txt \
@@ -332,6 +336,7 @@ jobs:
             --generation-status "$GENERATION_STATUS" \
             --old-version "$OLD_VERSION" \
             --new-version "$NEW_VERSION" \
+            --run-url "$RUN_URL" \
             > .sdk-update/pr-body.md
 
       # ----- Force-push to auto/sdk-update ----------------------------------

--- a/scripts/build_pr_body.py
+++ b/scripts/build_pr_body.py
@@ -34,6 +34,13 @@ import json
 import sys
 from pathlib import Path
 
+# GitHub caps PR body length at 65,536 characters; gh pr create/edit fails
+# the whole call if we go over. Aim for a budget below that to leave
+# headroom for trailing newlines, gh's own formatting, and any unicode
+# expansion in the GraphQL payload.
+GITHUB_PR_BODY_LIMIT = 65_536
+SAFE_BUDGET = 60_000
+
 
 def read_optional(path: str | None) -> str:
     if not path:
@@ -42,6 +49,26 @@ def read_optional(path: str | None) -> str:
     if not file_path.exists():
         return ""
     return file_path.read_text(encoding="utf-8")
+
+
+def truncate_at_line(content: str, max_chars: int, suffix: str = "") -> str:
+    """Truncate `content` to at most `max_chars` (counting `suffix`).
+
+    Slices on a line boundary so we never cut mid-line, then appends
+    `suffix`. If `content` already fits, returns it unchanged. If the
+    suffix alone is bigger than `max_chars`, returns just the suffix
+    (better to surface the truncation notice than silently drop it).
+    """
+    if len(content) <= max_chars:
+        return content
+    if len(suffix) >= max_chars:
+        return suffix
+    target = max_chars - len(suffix)
+    head = content[:target]
+    last_newline = head.rfind("\n")
+    if last_newline > 0:
+        head = head[:last_newline]
+    return head + suffix
 
 
 def parse_classification(text: str) -> tuple[str, str]:
@@ -134,20 +161,10 @@ def build(args: argparse.Namespace) -> str:
             )
         )
 
-    # --- oasdiff markdown changelog ----------------------------------------
-    changelog_md = read_optional(args.changelog_md).strip()
-    if changelog_md:
-        sections.append(
-            "<details>\n"
-            "<summary><strong>API changelog</strong> (from oasdiff)</summary>\n\n"
-            f"{changelog_md}\n"
-            "</details>"
-        )
-
     # --- Changes since last review -----------------------------------------
     delta = read_optional(args.since_last_review).strip()
     if delta:
-        sections.append(
+        delta_section = (
             "<details>\n"
             "<summary><strong>Changes since last review</strong></summary>\n\n"
             "```diff\n"
@@ -156,16 +173,84 @@ def build(args: argparse.Namespace) -> str:
             "</details>"
         )
     else:
-        sections.append(
+        delta_section = (
             "## Changes since last review\n\n_Initial PR — no prior review baseline._"
         )
 
     # --- Footer -------------------------------------------------------------
-    sections.append(
+    footer = (
         "---\n"
         "_This PR was opened automatically by the `sdk-update` workflow._\n"
         "_Trigger: `workflow_dispatch`._"
     )
+
+    # --- oasdiff markdown changelog (size-budgeted) -------------------------
+    # We build this LAST so we can size it against the remaining budget. The
+    # changelog is the dominant size in practice (an oasdiff markdown for a
+    # major spec rewrite can be 100+ KB, well over GitHub's 65,536-char PR
+    # body limit). Everything before/after the changelog has a stable upper
+    # bound, so we treat the rest of the body as "fixed cost" and give the
+    # changelog whatever budget is left.
+    changelog_md = read_optional(args.changelog_md).strip()
+    fixed_sections = sections + [delta_section, footer]
+    # +2 chars per join boundary, +1 for the trailing newline we add at the
+    # bottom of the final body. Keep this estimation conservative — the
+    # cost of under-allocating is a softer notice; the cost of
+    # over-allocating is a hard PR-create failure.
+    fixed_size = sum(len(s) for s in fixed_sections) + 2 * len(fixed_sections) + 1
+
+    if changelog_md:
+        wrapper_overhead = (
+            "<details>\n"
+            "<summary><strong>API changelog</strong> (from oasdiff)</summary>\n\n"
+            "\n"
+            "</details>"
+        )
+        # Reserve room for the wrapper plus the joiner between this section
+        # and the next one.
+        budget_for_changelog_content = (
+            SAFE_BUDGET - fixed_size - len(wrapper_overhead) - 2
+        )
+        if budget_for_changelog_content > 0 and len(changelog_md) > budget_for_changelog_content:
+            suffix = (
+                "\n\n_…changelog truncated to fit GitHub's PR body size limit."
+            )
+            if args.run_url:
+                suffix += (
+                    f" Full changelog available as `.sdk-update/analysis/changelog.md`"
+                    f" in the workflow run: {args.run_url}"
+                )
+            else:
+                suffix += (
+                    " Full changelog available as `.sdk-update/analysis/changelog.md`"
+                    " in the workflow run logs."
+                )
+            suffix += "_"
+            changelog_md = truncate_at_line(
+                changelog_md, budget_for_changelog_content, suffix=suffix
+            )
+        if budget_for_changelog_content > 0:
+            sections.append(
+                "<details>\n"
+                "<summary><strong>API changelog</strong> (from oasdiff)</summary>\n\n"
+                f"{changelog_md}\n"
+                "</details>"
+            )
+        else:
+            # Pathological: even the wrapper doesn't fit. Skip the changelog
+            # rather than fail the PR create.
+            note = (
+                "_API changelog omitted to fit GitHub's PR body size limit._"
+            )
+            if args.run_url:
+                note = (
+                    f"_API changelog omitted to fit GitHub's PR body size limit."
+                    f" See workflow run: {args.run_url}_"
+                )
+            sections.append(note)
+
+    sections.append(delta_section)
+    sections.append(footer)
 
     return "\n\n".join(sections) + "\n"
 
@@ -184,6 +269,16 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--old-version", default="")
     parser.add_argument("--new-version", default="")
+    parser.add_argument(
+        "--run-url",
+        default="",
+        help=(
+            "URL of this workflow run, used in the truncation notice when "
+            "the oasdiff changelog is too big to fit in the PR body. "
+            "Typically passed as ${{ github.server_url }}/${{ github.repository "
+            "}}/actions/runs/${{ github.run_id }}."
+        ),
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Summary

Follow-up to [#83](https://github.com/BambooHR/bhr-api-php/pull/83). The first sdk-update run after that merge got past \`composer install\` but [failed at \`gh pr create\`](https://github.com/BambooHR/bhr-api-php/actions/runs/26780073155):

\`\`\`
pull request create failed: GraphQL: Body is too long (maximum is 65536 characters)
\`\`\`

The oasdiff markdown changelog for a major spec rewrite (863 ERR-level breaking changes) is ~100 KB on its own, well past GitHub's hard 65,536-char cap on PR bodies.

## Fix

Size-budget the changelog section in \`build_pr_body.py\`. Build all other sections optimistically (banner, metadata, classification, version bump, delta, footer), treat their total length as fixed cost, give the changelog whatever budget is left under \`SAFE_BUDGET = 60_000\` chars (under the 65,536 hard cap, with headroom for joins, trailing newlines, and gh's GraphQL serialization).

When the changelog overflows:
- \`truncate_at_line()\` slices on a line boundary so we never cut mid-line
- A notice appended at the end with the run URL points reviewers to \`.sdk-update/analysis/changelog.md\` in the workflow run

\`build_pr_body.py\` gained a \`--run-url\` flag; the workflow passes \`\${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}\`.

## Verified locally

| Input changelog | Output body | Outcome |
|---|---|---|
| 200 chars | 580 chars | Pass-through, no truncation |
| 120,032 chars | 59,990 chars | Truncated at line boundary, suffix notice with run URL, \`<details>\` wrapper preserved, downstream sections intact |

## Test plan

- [ ] Trigger \`sdk-update.yml\` after merge and confirm \`gh pr create/edit\` succeeds. If the bot PR shows the truncation notice with a run-URL link, both sides of the fix are working.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes PR markdown composition and workflow env wiring for the bot; no runtime SDK or API behavior.
> 
> **Overview**
> **Fixes automated SDK update PRs failing when the oasdiff markdown changelog exceeds GitHub’s ~65 KB PR body limit** (e.g. large spec rewrites).
> 
> `build_pr_body.py` now treats banners, metadata, classification, version bump, “since last review”, and footer as fixed-size sections, then **fits the API changelog into the remaining budget** under `SAFE_BUDGET` (60k chars). Oversized changelogs are cut with **`truncate_at_line()`** (line-boundary safe) and a notice pointing reviewers to the full file in the workflow run. If no budget remains, the changelog is **omitted** with a short note instead of breaking `gh pr create/edit`.
> 
> The **`sdk-update` workflow** passes **`--run-url`** (Actions run link) into the script for those truncation/omit messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33218db5f5bd11eb459c84bf884acd948da9432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->