### PR TITLE
[SPN-2933] Prefix digit-named inline-schema classes with underscore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ generate:
 		&& ./scripts/normalize_line_breaks.sh ./lib ./test \
 		&& ./scripts/update_error_docs.sh \
 		&& ./scripts/add_custom_headers_to_api_docs.sh \
-		&& ./scripts/cleanup_obsolete_files.sh --force
+		&& ./scripts/cleanup_obsolete_files.sh --force \
+		&& php ./scripts/fix_invalid_class_names.php
 	@echo "SDK generation complete!"
 
 generate-error-docs:

--- a/scripts/fix_invalid_class_names.php
+++ b/scripts/fix_invalid_class_names.php
@@ -95,11 +95,27 @@ function rewriteFile(string $path, array $renames): bool {
     }
     $updated = $original;
     foreach ($renames as $oldName => $newName) {
-        $updated = preg_replace(
+        $result = preg_replace(
             '/\b' . preg_quote($oldName, '/') . '\b/',
             $newName,
             $updated
         );
+        // preg_replace returns null on a PCRE error (backtrack/JIT-stack
+        // limit, bad UTF-8, etc.). Without this guard the null would slip
+        // past the `$updated === $original` check below (null !== string)
+        // and file_put_contents() would blank the file — silently
+        // destroying generated source mid-rename. Abort loudly instead:
+        // a half-rewritten tree is worse than a failed pipeline step.
+        if ($result === null) {
+            fwrite(
+                STDERR,
+                "  ERROR: preg_replace failed (" . preg_last_error_msg() . ") "
+                . "while rewriting '$oldName' in $path. Aborting to avoid "
+                . "corrupting the file.\n"
+            );
+            exit(1);
+        }
+        $updated = $result;
     }
     if ($updated === $original) {
         return false;

--- a/scripts/fix_invalid_class_names.php
+++ b/scripts/fix_invalid_class_names.php
@@ -1,0 +1,154 @@
+#!/usr/bin/env php
+<?php
+/**
+ * fix_invalid_class_names.php — work around an openapi-generator PHP bug.
+ *
+ * Background
+ * ----------
+ * When a spec contains inline schemas that lack a `title` field AND the
+ * enclosing operation lacks a clean `operationId`, openapi-generator
+ * invents a name by hashing the operation. For Python it emits something
+ * like `_3958585c861325ea7a2cd30a8c74f042_request` — the leading
+ * underscore makes the name a valid Python identifier. For PHP it strips
+ * the underscore and emits raw hex like `3958585c861325ea7a2cd30a8c74f042Request`,
+ * which is a PHP **syntax error** at parse time (`unexpected integer "3958585"`).
+ *
+ * Affected lines look like:
+ *   lib/Model/1d64402ee192568adbd5e3179a91e6e2RequestInner.php
+ *     class 1d64402ee192568adbd5e3179a91e6e2RequestInner extends ...
+ *
+ * This script
+ * -----------
+ *   1. Finds every `lib/Model/<digit>*.php` file.
+ *   2. For each, renames the class to `_<original>` (matching the convention
+ *      Python's generator follows) and renames the file to match.
+ *   3. Rewrites cross-references throughout `lib/`, `test/`, and `docs/`:
+ *        - `BhrSdk\Model\1d64...` → `BhrSdk\Model\_1d64...`
+ *        - bare `1d64...::class` → `_1d64...::class`
+ *        - `'1d64...'` in serializer maps (ObjectSerializer / etc.)
+ *
+ * Run as a post-generation step from the Makefile. Re-running is safe:
+ * once a class has been prefixed with `_` it no longer starts with a
+ * digit, so the next pass leaves it alone.
+ *
+ * If/when upstream openapi-generator fixes the PHP target's inline-schema
+ * naming (or the source spec adds proper `title` / `operationId` values),
+ * this script can be deleted and removed from the Makefile.
+ */
+
+declare(strict_types=1);
+
+const MODEL_DIR = __DIR__ . '/../lib/Model';
+const SCAN_ROOTS = [
+    __DIR__ . '/../lib',
+    __DIR__ . '/../test',
+    __DIR__ . '/../docs',
+];
+
+function findBrokenModels(string $dir): array {
+    if (!is_dir($dir)) {
+        return [];
+    }
+    $broken = [];
+    foreach (scandir($dir) as $entry) {
+        if (preg_match('/^([0-9][A-Za-z0-9_]*)\.php$/', $entry, $matches)) {
+            $broken[] = $matches[1];  // class name without .php
+        }
+    }
+    return $broken;
+}
+
+function rewriteFile(string $path, array $renames): bool {
+    $original = file_get_contents($path);
+    if ($original === false) {
+        fwrite(STDERR, "  WARN: unreadable: $path\n");
+        return false;
+    }
+    $updated = $original;
+    foreach ($renames as $oldName => $newName) {
+        // Replace the bare token wherever it appears as an identifier.
+        // Word boundaries (\b) keep us from clobbering substrings of
+        // longer hex hashes (e.g. a 32-char hash that happens to contain
+        // a 30-char hash as a prefix).
+        $updated = preg_replace(
+            '/\b' . preg_quote($oldName, '/') . '\b/',
+            $newName,
+            $updated
+        );
+    }
+    if ($updated === $original) {
+        return false;
+    }
+    file_put_contents($path, $updated);
+    return true;
+}
+
+function walkPhpFiles(string $dir, callable $fn): void {
+    if (!is_dir($dir)) {
+        return;
+    }
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+    foreach ($iterator as $file) {
+        if ($file->getExtension() === 'php' || $file->getExtension() === 'md') {
+            $fn($file->getPathname());
+        }
+    }
+}
+
+// ---- main -----------------------------------------------------------------
+
+$broken = findBrokenModels(MODEL_DIR);
+
+if (empty($broken)) {
+    echo "fix_invalid_class_names: no models with digit-prefixed names found, nothing to do.\n";
+    exit(0);
+}
+
+echo "fix_invalid_class_names: found " . count($broken) . " digit-prefixed class(es):\n";
+foreach ($broken as $name) {
+    echo "  - $name\n";
+}
+
+// Build rename map: oldName => newName
+$renames = [];
+foreach ($broken as $name) {
+    $renames[$name] = '_' . $name;
+}
+
+// 1. Rename files in lib/Model/ and rewrite their internal references.
+foreach ($renames as $oldName => $newName) {
+    $oldPath = MODEL_DIR . "/$oldName.php";
+    $newPath = MODEL_DIR . "/$newName.php";
+    if (!file_exists($oldPath)) {
+        fwrite(STDERR, "  WARN: expected file missing: $oldPath\n");
+        continue;
+    }
+    // Rewrite class name inside before renaming the file.
+    rewriteFile($oldPath, [$oldName => $newName]);
+    if (!rename($oldPath, $newPath)) {
+        fwrite(STDERR, "  ERROR: rename failed: $oldPath -> $newPath\n");
+        exit(1);
+    }
+    echo "  Renamed $oldName -> $newName\n";
+}
+
+// 2. Update cross-references everywhere else (other models, API classes,
+//    serializer maps, docs, tests).
+$touched = 0;
+foreach (SCAN_ROOTS as $root) {
+    walkPhpFiles($root, function (string $path) use ($renames, &$touched): void {
+        if (rewriteFile($path, $renames)) {
+            $touched++;
+        }
+    });
+}
+echo "fix_invalid_class_names: updated references in $touched file(s).\n";
+
+// 3. Patch .openapi-generator/FILES so the cleanup script doesn't think the
+//    renamed files are "obsolete" on the next run.
+$filesManifest = __DIR__ . '/../.openapi-generator/FILES';
+if (file_exists($filesManifest)) {
+    if (rewriteFile($filesManifest, $renames)) {
+        echo "fix_invalid_class_names: patched .openapi-generator/FILES manifest.\n";
+    }
+}

--- a/scripts/fix_invalid_class_names.php
+++ b/scripts/fix_invalid_class_names.php
@@ -13,23 +13,27 @@
  * the underscore and emits raw hex like `3958585c861325ea7a2cd30a8c74f042Request`,
  * which is a PHP **syntax error** at parse time (`unexpected integer "3958585"`).
  *
- * Affected lines look like:
- *   lib/Model/1d64402ee192568adbd5e3179a91e6e2RequestInner.php
- *     class 1d64402ee192568adbd5e3179a91e6e2RequestInner extends ...
- *
  * This script
  * -----------
- *   1. Finds every `lib/Model/<digit>*.php` file.
- *   2. For each, renames the class to `_<original>` (matching the convention
- *      Python's generator follows) and renames the file to match.
- *   3. Rewrites cross-references throughout `lib/`, `test/`, and `docs/`:
- *        - `BhrSdk\Model\1d64...` → `BhrSdk\Model\_1d64...`
- *        - bare `1d64...::class` → `_1d64...::class`
- *        - `'1d64...'` in serializer maps (ObjectSerializer / etc.)
+ *   1. Finds every `lib/Model/<digit>*.php`.
+ *   2. For each, locates the associated derived files:
+ *        - `lib/Model/<name>.php`   (the class)
+ *        - `docs/Model/<name>.md`   (the doc page)
+ *        - `test/Model/<name>Test.php` (only when --global-property
+ *          modelTests is not false — we set it false, so usually absent)
+ *      and renames them to `_<name>.…`.
+ *   3. Rewrites every cross-reference in the rest of the SDK:
+ *        - `BhrSdk\Model\1d64...` and bare `1d64...::class`
+ *        - markdown link text and link targets like `[1d64...](1d64...md)`
+ *        - entries in `.openapi-generator/FILES` (both `.php` and `.md`
+ *          paths) so the obsolete-cleanup pass on the next regen doesn't
+ *          think the renamed files are stale
+ *        - the top-level `README.md`, which openapi-generator regenerates
+ *          and which links to every model under `docs/Model/`.
  *
- * Run as a post-generation step from the Makefile. Re-running is safe:
- * once a class has been prefixed with `_` it no longer starts with a
- * digit, so the next pass leaves it alone.
+ * Re-running is safe: once a class has been prefixed with `_` it no
+ * longer starts with a digit, so the scanner finds nothing on the next
+ * pass.
  *
  * If/when upstream openapi-generator fixes the PHP target's inline-schema
  * naming (or the source spec adds proper `title` / `operationId` values),
@@ -38,13 +42,27 @@
 
 declare(strict_types=1);
 
-const MODEL_DIR = __DIR__ . '/../lib/Model';
+const PROJECT_ROOT = __DIR__ . '/..';
+const MODEL_DIR    = PROJECT_ROOT . '/lib/Model';
+const DOCS_MODEL_DIR = PROJECT_ROOT . '/docs/Model';
+const TEST_MODEL_DIR = PROJECT_ROOT . '/test/Model';
+const FILES_MANIFEST = PROJECT_ROOT . '/.openapi-generator/FILES';
+const README         = PROJECT_ROOT . '/README.md';
+
+// Directories whose .php and .md content we rewrite via the renames map.
+// README.md is added explicitly below (it's a single top-level file, not
+// a directory tree, so the recursive walker doesn't naturally see it).
 const SCAN_ROOTS = [
-    __DIR__ . '/../lib',
-    __DIR__ . '/../test',
-    __DIR__ . '/../docs',
+    PROJECT_ROOT . '/lib',
+    PROJECT_ROOT . '/test',
+    PROJECT_ROOT . '/docs',
 ];
 
+/**
+ * Discover every digit-prefixed model basename in lib/Model/.
+ *
+ * Returns an array of class names (without the .php extension).
+ */
 function findBrokenModels(string $dir): array {
     if (!is_dir($dir)) {
         return [];
@@ -52,24 +70,31 @@ function findBrokenModels(string $dir): array {
     $broken = [];
     foreach (scandir($dir) as $entry) {
         if (preg_match('/^([0-9][A-Za-z0-9_]*)\.php$/', $entry, $matches)) {
-            $broken[] = $matches[1];  // class name without .php
+            $broken[] = $matches[1];
         }
     }
+    sort($broken);
     return $broken;
 }
 
+/**
+ * Apply a {oldName => newName} substitution to a single file. Returns
+ * true iff the file actually changed.
+ *
+ * Uses \b word boundaries so a short token can't accidentally match
+ * inside a longer one — e.g. when both `1d64aRequest` and
+ * `1d64aRequestInner` need renaming, processing one won't clobber the
+ * other (the `r` ↔ `I` transition between them is word-char ↔ word-char,
+ * no boundary).
+ */
 function rewriteFile(string $path, array $renames): bool {
-    $original = file_get_contents($path);
+    $original = @file_get_contents($path);
     if ($original === false) {
         fwrite(STDERR, "  WARN: unreadable: $path\n");
         return false;
     }
     $updated = $original;
     foreach ($renames as $oldName => $newName) {
-        // Replace the bare token wherever it appears as an identifier.
-        // Word boundaries (\b) keep us from clobbering substrings of
-        // longer hex hashes (e.g. a 32-char hash that happens to contain
-        // a 30-char hash as a prefix).
         $updated = preg_replace(
             '/\b' . preg_quote($oldName, '/') . '\b/',
             $newName,
@@ -83,16 +108,36 @@ function rewriteFile(string $path, array $renames): bool {
     return true;
 }
 
-function walkPhpFiles(string $dir, callable $fn): void {
+/**
+ * Recurse `$dir` and call `$fn($absPath)` for each .php / .md file.
+ */
+function walkSourceFiles(string $dir, callable $fn): void {
     if (!is_dir($dir)) {
         return;
     }
     $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
     foreach ($iterator as $file) {
-        if ($file->getExtension() === 'php' || $file->getExtension() === 'md') {
+        $ext = strtolower($file->getExtension());
+        if ($ext === 'php' || $ext === 'md') {
             $fn($file->getPathname());
         }
     }
+}
+
+/**
+ * Rename `$oldPath` to `$newPath` if `$oldPath` exists. Returns true on
+ * actual rename, false if the source file wasn't present (which is fine
+ * — not every model has every kind of derived file).
+ */
+function renameIfExists(string $oldPath, string $newPath): bool {
+    if (!file_exists($oldPath)) {
+        return false;
+    }
+    if (!rename($oldPath, $newPath)) {
+        fwrite(STDERR, "  ERROR: rename failed: $oldPath -> $newPath\n");
+        exit(1);
+    }
+    return true;
 }
 
 // ---- main -----------------------------------------------------------------
@@ -115,40 +160,51 @@ foreach ($broken as $name) {
     $renames[$name] = '_' . $name;
 }
 
-// 1. Rename files in lib/Model/ and rewrite their internal references.
+// Step 1: Rename the derived files for each broken model. The PHP class
+// itself + its markdown doc + its optional test stub. The class file is
+// guaranteed to exist (we found it via scandir above); the others are
+// best-effort.
+$renamedCount = ['php' => 0, 'md' => 0, 'test' => 0];
 foreach ($renames as $oldName => $newName) {
-    $oldPath = MODEL_DIR . "/$oldName.php";
-    $newPath = MODEL_DIR . "/$newName.php";
-    if (!file_exists($oldPath)) {
-        fwrite(STDERR, "  WARN: expected file missing: $oldPath\n");
-        continue;
+    if (renameIfExists(MODEL_DIR . "/$oldName.php", MODEL_DIR . "/$newName.php")) {
+        $renamedCount['php']++;
     }
-    // Rewrite class name inside before renaming the file.
-    rewriteFile($oldPath, [$oldName => $newName]);
-    if (!rename($oldPath, $newPath)) {
-        fwrite(STDERR, "  ERROR: rename failed: $oldPath -> $newPath\n");
-        exit(1);
+    if (renameIfExists(DOCS_MODEL_DIR . "/$oldName.md", DOCS_MODEL_DIR . "/$newName.md")) {
+        $renamedCount['md']++;
     }
-    echo "  Renamed $oldName -> $newName\n";
+    if (renameIfExists(TEST_MODEL_DIR . "/{$oldName}Test.php", TEST_MODEL_DIR . "/{$newName}Test.php")) {
+        $renamedCount['test']++;
+    }
 }
+echo "fix_invalid_class_names: renamed {$renamedCount['php']} .php / "
+   . "{$renamedCount['md']} .md / {$renamedCount['test']} test file(s).\n";
 
-// 2. Update cross-references everywhere else (other models, API classes,
-//    serializer maps, docs, tests).
+// Step 2: Rewrite cross-references across lib/, test/, docs/. This pass
+// updates: the renamed class file's internal `class …` declaration,
+// `use` statements in importers, type hints, markdown link text, and
+// markdown link targets. Walks .php and .md.
 $touched = 0;
 foreach (SCAN_ROOTS as $root) {
-    walkPhpFiles($root, function (string $path) use ($renames, &$touched): void {
+    walkSourceFiles($root, function (string $path) use ($renames, &$touched): void {
         if (rewriteFile($path, $renames)) {
             $touched++;
         }
     });
 }
+
+// Step 3: Top-level README.md is regenerated by openapi-generator and
+// links into docs/Model/. It's outside SCAN_ROOTS, so handle it
+// explicitly. Skipping silently if absent (some setups may .ignore it).
+if (file_exists(README) && rewriteFile(README, $renames)) {
+    $touched++;
+}
+
 echo "fix_invalid_class_names: updated references in $touched file(s).\n";
 
-// 3. Patch .openapi-generator/FILES so the cleanup script doesn't think the
-//    renamed files are "obsolete" on the next run.
-$filesManifest = __DIR__ . '/../.openapi-generator/FILES';
-if (file_exists($filesManifest)) {
-    if (rewriteFile($filesManifest, $renames)) {
-        echo "fix_invalid_class_names: patched .openapi-generator/FILES manifest.\n";
-    }
+// Step 4: Patch the FILES manifest so the obsolete-cleanup pass on the
+// NEXT regen doesn't think the underscored paths are missing files. The
+// manifest contains both .php and .md paths, both of which must move in
+// lockstep with the actual renames above.
+if (file_exists(FILES_MANIFEST) && rewriteFile(FILES_MANIFEST, $renames)) {
+    echo "fix_invalid_class_names: patched .openapi-generator/FILES manifest.\n";
 }

--- a/scripts/fix_invalid_class_names.php
+++ b/scripts/fix_invalid_class_names.php
@@ -142,6 +142,28 @@ function renameIfExists(string $oldPath, string $newPath): bool {
 
 // ---- main -----------------------------------------------------------------
 
+// Sanity guard: this fix targets lib/Model/ only. Digit-prefixed names come
+// from inline request/response schemas that openapi-generator hashes when
+// they lack a `title`; those always land in lib/Model/. API classes
+// (lib/Api/) are named from OpenAPI tags, which are human-readable and never
+// hashed, so a digit-prefixed API class should be impossible. If that
+// assumption ever breaks, fail loudly here rather than letting smoke_test.php
+// (which autoloads lib/Api/ too) surface it as a confusing autoload error.
+$brokenApis = findBrokenModels(PROJECT_ROOT . '/lib/Api');
+if (!empty($brokenApis)) {
+    fwrite(STDERR, "fix_invalid_class_names: ERROR — digit-prefixed class(es) found in lib/Api/:\n");
+    foreach ($brokenApis as $name) {
+        fwrite(STDERR, "  - $name\n");
+    }
+    fwrite(
+        STDERR,
+        "This script only handles lib/Model/. API classes were assumed to be\n"
+        . "tag-derived and never hash-named — that assumption no longer holds.\n"
+        . "Extend this script to cover lib/Api/ (+ docs/Api/, test/Api/).\n"
+    );
+    exit(1);
+}
+
 $broken = findBrokenModels(MODEL_DIR);
 
 if (empty($broken)) {
@@ -154,25 +176,46 @@ foreach ($broken as $name) {
     echo "  - $name\n";
 }
 
-// Build rename map: oldName => newName
+// Build the token-rename map applied to file *contents* (class
+// declarations, `use` statements, type hints, markdown links, manifest
+// paths). For each broken model we always rename the model class token.
+//
+// Model test stubs (emitted only when --global-property modelTests isn't
+// false) are named `<name>Test`, and that class ALSO starts with a digit.
+// It needs its own entry because rewriteFile()'s \b boundary cannot match
+// the `<name>` token inside `<name>Test`: the join is t→T, word-char to
+// word-char, so there's no boundary for `\b<name>\b` to anchor on. A lone
+// `<name>` entry would leave `class <name>Test`, its `<name>Test` manifest
+// path, and any `<name>Test::class` references digit-prefixed — still a
+// PHP syntax error.
+//
+// Entry order is irrelevant: every key is matched with \b on both ends,
+// so `<name>` can never match inside the longer `<name>Test` token and
+// vice-versa, regardless of which is substituted first.
 $renames = [];
 foreach ($broken as $name) {
     $renames[$name] = '_' . $name;
+    if (file_exists(TEST_MODEL_DIR . "/{$name}Test.php")) {
+        $renames["{$name}Test"] = "_{$name}Test";
+    }
 }
 
-// Step 1: Rename the derived files for each broken model. The PHP class
-// itself + its markdown doc + its optional test stub. The class file is
-// guaranteed to exist (we found it via scandir above); the others are
-// best-effort.
+// Step 1: Physically rename the derived files for each broken model — the
+// PHP class itself + its markdown doc + its optional test stub. Iterate
+// $broken (one model => one set of files) rather than $renames, since
+// $renames now also contains the `<name>Test` content-token which has no
+// independent file of its own. The class file is guaranteed to exist (we
+// found it via scandir above); the doc and test files are best-effort.
 $renamedCount = ['php' => 0, 'md' => 0, 'test' => 0];
-foreach ($renames as $oldName => $newName) {
-    if (renameIfExists(MODEL_DIR . "/$oldName.php", MODEL_DIR . "/$newName.php")) {
+foreach ($broken as $name) {
+    $newName = '_' . $name;
+    if (renameIfExists(MODEL_DIR . "/$name.php", MODEL_DIR . "/$newName.php")) {
         $renamedCount['php']++;
     }
-    if (renameIfExists(DOCS_MODEL_DIR . "/$oldName.md", DOCS_MODEL_DIR . "/$newName.md")) {
+    if (renameIfExists(DOCS_MODEL_DIR . "/$name.md", DOCS_MODEL_DIR . "/$newName.md")) {
         $renamedCount['md']++;
     }
-    if (renameIfExists(TEST_MODEL_DIR . "/{$oldName}Test.php", TEST_MODEL_DIR . "/{$newName}Test.php")) {
+    if (renameIfExists(TEST_MODEL_DIR . "/{$name}Test.php", TEST_MODEL_DIR . "/{$newName}Test.php")) {
         $renamedCount['test']++;
     }
 }


### PR DESCRIPTION
## Summary

The latest sdk-update workflow run made it through composer install + generate + format + lint, then [died at \`make smoke-test\`](https://github.com/BambooHR/bhr-api-php/actions/runs/<run>):

\`\`\`
syntax error, unexpected integer "1", expecting identifier
syntax error, unexpected integer "3958585", expecting identifier
... (8 total)
\`\`\`

PHP identifiers cannot start with a digit, but the generator produced classes like:

\`\`\`php
class 1d64402ee192568adbd5e3179a91e6e2RequestInner extends ...
class 3958585c861325ea7a2cd30a8c74f042Request extends ...
\`\`\`

These are MD5 hashes of operation paths. \`openapi-generator-cli\` falls back to hashing when an inline schema has no \`title\` field AND the operation's \`operationId\` is itself non-identifier-shaped (which for our spec it is — a 32-char hex string).

## Why Python's SDK doesn't hit this

The Python target emits names like \`_3958585c861325ea7a2cd30a8c74f042_request\` (leading underscore + snake_case). Valid Python identifier. The PHP target strips the underscore convention and emits raw hex. Invalid PHP.

## Fix

Post-generation step \`scripts/fix_invalid_class_names.php\`:

1. Finds every \`lib/Model/<digit>*.php\`
2. Renames the class to \`_<original>\` (mirroring Python's convention) and the file to match
3. Rewrites every cross-reference in \`lib/\`, \`test/\`, \`docs/\` (\`use ...\\Model\\1d64...\`, bare \`::class\` refs, etc.)
4. Patches \`.openapi-generator/FILES\` so obsolete-files cleanup doesn't treat the renamed files as stale on the next run

Wired into the Makefile's \`generate\` target after \`cleanup_obsolete_files.sh\`. Re-running is a clean no-op (prefixed names don't start with a digit, scanner finds nothing).

## Verified locally

Built a synthetic fixture: a digit-prefixed model file plus an importing class referencing it. After the fix:
- File renamed
- Class declaration patched
- \`use\` statement + property type hint in importing file updated
- FILES manifest patched
- \`php -l\` reports no syntax errors on either file

## Long-term

The right fix is upstream — either openapi-generator's PHP target gets the same underscore convention the Python target uses, or the source spec gets \`title\` fields on inline schemas. Both are real but out of process for us. This script is the workaround until one of those happens; when it does, delete the script and the Makefile line.

## Test plan

- [ ] Trigger \`sdk-update.yml\` after merge and confirm \`make smoke-test\` passes against the latest spec.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time-only rename of generated artifacts; no runtime API or auth changes, with guards against partial file corruption during rewrite.
> 
> **Overview**
> Adds a **post-generation workaround** so the PHP SDK no longer ships **parse-invalid model classes** whose names start with a digit (hash-derived inline schemas from openapi-generator).
> 
> After `make generate`, **`scripts/fix_invalid_class_names.php`** runs: it finds digit-prefixed `lib/Model/*.php`, renames classes/files/docs/tests to a leading-underscore form (aligned with the Python SDK convention), rewrites references across `lib/`, `test/`, `docs/`, `README.md`, and **`.openapi-generator/FILES`**, and exits early if digit-prefixed names appear under `lib/Api/`. The step is **idempotent** on repeat generation.
> 
> This unblocks **`make smoke-test`** / CI, which were failing on syntax errors before autoload could succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ded30414c9085402e82d882d9f37911f6f7e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->